### PR TITLE
Migrate to BlockModelV3

### DIFF
--- a/.changeset/peptide-universalize.md
+++ b/.changeset/peptide-universalize.md
@@ -1,0 +1,18 @@
+---
+"@platforma-open/milaboratories.immune-assay-data.workflow": minor
+"@platforma-open/milaboratories.immune-assay-data.model": minor
+"@platforma-open/milaboratories.immune-assay-data.ui": minor
+"@platforma-open/milaboratories.immune-assay-data": minor
+---
+
+Accept peptide datasets alongside VDJ clonotypes; rename to "Sequence Assay Data".
+
+The block now discovers peptide-extraction anchors (`pl7.app/variantKey`) in addition to bulk and single-cell VDJ; target-column selection branches on the dataset axis. A new retentive `modality` model output exposes `'peptide' | 'antibody_tcr'` derived from the dataset spec. The UI applies modality-aware threshold defaults — antibody/TCR keeps the previous BLOSUM defaults (`alignment-score / 0.9 / 0.95`); peptide flips to exact-match (`sequence-identity / 1.0 / 1.0`). Switching between datasets of the same modality preserves user-tuned thresholds; legacy projects' tuning is preserved via `lastAppliedModality: 'antibody_tcr'` in `upgradeLegacy`.
+
+Block-emitted column and axis names are now modality-neutral — `pl7.app/assay-data/*`, `pl7.app/assay/queryCount`, `pl7.app/sequence` (assay sequence), `pl7.app/assay/sequenceId`, `pl7.app/assay/sequenceIdLabel`, `pl7.app/link`. The `assay/` and `assay-data/` sub-namespaces remain; modality is recovered by consumers from the natural input axis on each column. Downstream blocks consuming via axis-anchored queries are unaffected.
+
+Short-peptide k-mer override: when the shortest input peptide is below 10 aa, the MMseqs2 prefilter is reconfigured for short sequences (`-k 5 --spaced-kmer-mode 0 --min-ungapped-score 0 -s 7.5 -e inf`). The spec called only for `-k 5`; the additional flags were required empirically to make sub-7-aa exact matches actually return hits — defaults silently filter them. Mirrors clonotype-clustering's `highPrecision` short-CDR mode. The override takes precedence over Fast mode's hardcoded `-k 7`.
+
+Block catalog name changes from "Immune Assay Data" to "Sequence Assay Data"; `block.meta.tags` gains `peptide`; description and long-form docs rewritten to be modality-neutral. The block ID, npm package name, and directory remain `immune-assay-data` — technical identifiers unchanged.
+
+UI: `isAssayColumn` and `isSequenceColumn` predicates updated for neutral names and the peptide variant axis; `isSequenceColumn` now reads both VDJ-namespaced and neutral `isAssemblingFeature` annotations so peptide aa columns are default-selected in the MSA dialog. Empty-state alert, target-dropdown label/tooltip, and coverage-threshold tooltip rewritten to drop VDJ flavor.

--- a/.changeset/v3-migration.md
+++ b/.changeset/v3-migration.md
@@ -1,0 +1,11 @@
+---
+"@platforma-open/milaboratories.immune-assay-data.model": minor
+"@platforma-open/milaboratories.immune-assay-data.ui": minor
+"@platforma-open/milaboratories.immune-assay-data": minor
+---
+
+Migrate block to BlockModelV3. Unified `BlockData` (UI-shaped persistence); `.args` lambda derives the workflow-visible shape and validates by throw; `.prerunArgs` projects `fileHandle` for the file-import prerun. Persisted V1 state preserved via `DataModelBuilder.upgradeLegacy`. UI bindings move to `app.model.data`; `defineApp` → `defineAppV3`.
+
+`defaultBlockLabel` is no longer stored: the args lambda and the subtitle derive it inline from `data.fileHandle + data.settings` (via the pure `getFileNameFromHandle`). The `syncDefaultBlockLabel` output→args watcher is removed.
+
+The file-bytes watcher in `MainPage.vue` is preserved with a comment: it remains an `outputs → data` write, but the parsing function is deterministic on the input bytes, so multi-client writes are idempotent.

--- a/block/package.json
+++ b/block/package.json
@@ -23,18 +23,19 @@
       "ui": "@platforma-open/milaboratories.immune-assay-data.ui/dist"
     },
     "meta": {
-      "title": "Immune Assay Data",
+      "title": "Sequence Assay Data",
       "logo": "file:../logos/block-logo.png",
       "url": "https://github.com/platforma-open/immune-assay-data",
       "docs": "https://docs.platforma.bio/guides/antibody-discovery/functinal-assay-data/",
       "support": "mailto:support@milaboratories.com",
-      "description": "Imports immune assay data and aligns clonotypes with assay sequences using MMseqs2 to assign functional annotations.",
+      "description": "Imports assay data and uses MMseqs2 to align its sequences to clonotypes or peptides and assign functional annotations.",
       "longDescription": "file:../docs/description.md",
       "changelog": "file:../CHANGELOG.md",
       "tags": [
         "airr",
         "downstream",
-        "assay"
+        "assay",
+        "peptide"
       ],
       "organization": {
         "name": "MiLaboratories Inc",

--- a/block/package.json
+++ b/block/package.json
@@ -23,7 +23,7 @@
       "ui": "@platforma-open/milaboratories.immune-assay-data.ui/dist"
     },
     "meta": {
-      "title": "Sequence Assay Data",
+      "title": "Import Assay Data",
       "logo": "file:../logos/block-logo.png",
       "url": "https://github.com/platforma-open/immune-assay-data",
       "docs": "https://docs.platforma.bio/guides/antibody-discovery/functinal-assay-data/",

--- a/docs/description.md
+++ b/docs/description.md
@@ -1,8 +1,8 @@
 # Overview
 
-Imports immune assay data containing nucleotide or amino acid sequences with associated metadata and aligns clonotypes from V(D)J analysis with the assay database to assign functional annotations. The block uses MMseqs2's easy-search functionality to perform sensitive sequence alignment between clonotype sequences and assay database sequences, assigning metadata (such as antigen specificity, binding affinity, or functional properties) to matching clonotypes.
+Imports assay data containing nucleotide or amino acid sequences with associated metadata and aligns it to clonotypes or peptides to assign functional annotations. The block uses MMseqs2's easy-search functionality to perform sensitive sequence alignment between input sequences and assay database sequences, assigning metadata (such as antigen specificity, binding affinity, or functional properties) to matching sequences.
 
-The enriched clonotype data with assay annotations can be used in downstream analysis blocks such as Clonotype Browser to filter, explore, and analyze clonotypes based on their functional properties.
+The enriched data with assay annotations can be used in downstream analysis blocks such as Sequence Browser to filter, explore, and analyze sequences based on their functional properties.
 
 MMseqs2 is developed by the Söding lab and Steinegger group. For more information, please see: [https://github.com/soedinglab/MMseqs2](https://github.com/soedinglab/MMseqs2) and cite the following publication if used in your research:
 

--- a/model/package.json
+++ b/model/package.json
@@ -22,7 +22,8 @@
   },
   "dependencies": {
     "@platforma-sdk/model": "catalog:",
-    "@milaboratories/graph-maker": "catalog:"
+    "@milaboratories/graph-maker": "catalog:",
+    "@milaboratories/helpers": "catalog:"
   },
   "devDependencies": {
     "@milaboratories/ts-builder": "catalog:",

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -261,7 +261,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .output('isRunning', (ctx) => ctx.outputs?.getIsReadyOrError() === false)
 
-  .title(() => 'Sequence Assay Data')
+  .title(() => 'Import Assay Data')
 
   .subtitle((ctx) => ctx.data.customBlockLabel || deriveDefaultLabel(ctx.data))
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,121 +1,131 @@
 import type {
   DataInfo,
-  ImportFileHandle,
+  InferOutputsType,
   PColumn,
   PColumnSpec,
   PColumnValues,
-  PlDataTableStateV2,
-  PlMultiSequenceAlignmentModel,
-  PlRef,
-  RenderCtxLegacy,
-  SUniversalPColumnId,
+  RenderCtxBase,
   TreeNodeAccessor,
 } from '@platforma-sdk/model';
 import {
-  BlockModel,
+  BlockModelV3,
   createPFrameForGraphs,
   createPlDataTableStateV2,
   createPlDataTableV2,
+  DataModelBuilder,
+  getFileNameFromHandle,
 } from '@platforma-sdk/model';
 import { getDefaultBlockLabel } from './label';
-
-type Settings = {
-  coverageThreshold: number; // fraction of aligned residues required
-  identity: number;
-  similarityType: 'sequence-identity' | 'alignment-score';
-};
-
-export type ImportColumnInfo = {
-  header: string;
-  type: 'Int' | 'Double' | 'String';
-  /** If this column is a sequence column, the type of the sequence */
-  sequenceType?: 'nucleotide' | 'aminoacid';
-};
-
-export type BlockArgs = {
-  defaultBlockLabel: string;
-  customBlockLabel: string;
-  datasetRef?: PlRef;
-  targetRef?: SUniversalPColumnId;
-  fileHandle?: ImportFileHandle;
-  fileExtension?: string;
-  detectedXsvType?: 'csv' | 'tsv';
-  importColumns?: ImportColumnInfo[];
-  sequenceColumnHeader?: string;
-  selectedColumns: string[];
-  settings: Settings;
-  lessSensitive: boolean;
-  mem?: number;
-  cpu?: number;
-};
-
-export type UiState = {
-  fileImportError?: string;
-  tableState: PlDataTableStateV2;
-  alignmentModel: PlMultiSequenceAlignmentModel;
-};
+import type {
+  BlockArgs,
+  BlockData,
+  BlockPrerunArgs,
+  LegacyBlockArgs,
+  LegacyBlockUiState,
+  Settings,
+} from './types';
 
 type Column = PColumn<DataInfo<TreeNodeAccessor> | TreeNodeAccessor | PColumnValues>;
 
-type Columns = {
-  props: Column[];
-};
+const defaultSettings = (): Settings => ({
+  coverageThreshold: 0.95,
+  identity: 0.9,
+  similarityType: 'alignment-score',
+});
 
-function getColumns(ctx: RenderCtxLegacy<BlockArgs, UiState>): Columns | undefined {
-  const anchor = ctx.args.datasetRef;
-  if (anchor === undefined)
-    return undefined;
-
-  const anchorSpec = ctx.resultPool.getPColumnSpecByRef(anchor);
-  if (anchorSpec === undefined)
-    return undefined;
-
-  // all clone properties
-  const props = (ctx.resultPool.getAnchoredPColumns(
-    { main: anchor },
-    [
-      {
-        axes: [{ anchor: 'main', idx: 1 }],
-      },
-    ]) ?? [])
-    .filter((p) => p.spec.annotations?.['pl7.app/sequence/isAnnotation'] !== 'true');
-
-  return {
-    props: props,
-  };
-}
-
-export const model = BlockModel.create()
-
-  .withArgs<BlockArgs>({
-    defaultBlockLabel: getDefaultBlockLabel({
-      similarityType: 'alignment-score',
-      identity: 0.9,
-      coverageThreshold: 0.95,
-    }),
+const blockDataModel = new DataModelBuilder()
+  .from<BlockData>('V20260519')
+  .upgradeLegacy<LegacyBlockArgs, LegacyBlockUiState>(({ args, uiState }) => ({
+    customBlockLabel: args?.customBlockLabel ?? '',
+    datasetRef: args?.datasetRef,
+    targetRef: args?.targetRef,
+    fileHandle: args?.fileHandle,
+    fileExtension: args?.fileExtension,
+    detectedXsvType: args?.detectedXsvType,
+    importColumns: args?.importColumns,
+    sequenceColumnHeader: args?.sequenceColumnHeader,
+    selectedColumns: args?.selectedColumns ?? [],
+    settings: args?.settings ?? defaultSettings(),
+    lessSensitive: args?.lessSensitive ?? false,
+    mem: args?.mem,
+    cpu: args?.cpu,
+    fileImportError: uiState?.fileImportError,
+    tableState: uiState?.tableState ?? createPlDataTableStateV2(),
+    alignmentModel: uiState?.alignmentModel ?? {},
+  }))
+  .init(() => ({
     customBlockLabel: '',
-    settings: {
-      coverageThreshold: 0.95, // default value matching MMseqs2 default
-      identity: 0.9,
-      similarityType: 'alignment-score',
-    },
+    datasetRef: undefined,
+    targetRef: undefined,
+    fileHandle: undefined,
+    fileExtension: undefined,
+    detectedXsvType: undefined,
+    importColumns: undefined,
+    sequenceColumnHeader: undefined,
     selectedColumns: [],
+    settings: defaultSettings(),
     lessSensitive: false,
-  })
-
-  .withUiState<UiState>({
+    mem: undefined,
+    cpu: undefined,
+    fileImportError: undefined,
     tableState: createPlDataTableStateV2(),
     alignmentModel: {},
+  }));
+
+function deriveDefaultLabel(data: BlockData): string {
+  return getDefaultBlockLabel({
+    fileName: data.fileHandle ? getFileNameFromHandle(data.fileHandle) : undefined,
+    similarityType: data.settings.similarityType,
+    identity: data.settings.identity,
+    coverageThreshold: data.settings.coverageThreshold,
+  });
+}
+
+function getAnchoredClonotypeProps(
+  ctx: Pick<RenderCtxBase<BlockArgs, BlockData>, 'data' | 'resultPool'>,
+): Column[] | undefined {
+  const anchor = ctx.data.datasetRef;
+  if (anchor === undefined) return undefined;
+  const anchorSpec = ctx.resultPool.getPColumnSpecByRef(anchor);
+  if (anchorSpec === undefined) return undefined;
+  return (ctx.resultPool.getAnchoredPColumns(
+    { main: anchor },
+    [{ axes: [{ anchor: 'main', idx: 1 }] }],
+  ) ?? []).filter(
+    (p) => p.spec.annotations?.['pl7.app/sequence/isAnnotation'] !== 'true',
+  );
+}
+
+export const platforma = BlockModelV3.create(blockDataModel)
+
+  .args<BlockArgs>((data) => {
+    if (data.datasetRef === undefined) throw new Error('Dataset is required');
+    if (data.targetRef === undefined) throw new Error('Target clonotype sequence is required');
+    if (data.fileHandle === undefined) throw new Error('Assay file is required');
+    if (data.importColumns === undefined) throw new Error('Assay file has not been parsed yet');
+    if (data.sequenceColumnHeader === undefined) throw new Error('Assay sequence column is required');
+    if (data.fileImportError !== undefined) throw new Error(data.fileImportError);
+
+    return {
+      defaultBlockLabel: deriveDefaultLabel(data),
+      customBlockLabel: data.customBlockLabel,
+      datasetRef: data.datasetRef,
+      targetRef: data.targetRef,
+      fileHandle: data.fileHandle,
+      detectedXsvType: data.detectedXsvType,
+      importColumns: data.importColumns,
+      sequenceColumnHeader: data.sequenceColumnHeader,
+      selectedColumns: data.selectedColumns,
+      settings: data.settings,
+      lessSensitive: data.lessSensitive,
+      mem: data.mem,
+      cpu: data.cpu,
+    };
   })
 
-  .argsValid((ctx) =>
-    ctx.args.datasetRef !== undefined
-    && ctx.args.fileHandle !== undefined
-    && ctx.args.importColumns !== undefined
-    && ctx.args.sequenceColumnHeader !== undefined
-    && ctx.args.targetRef !== undefined
-    && ctx.uiState.fileImportError === undefined,
-  )
+  .prerunArgs((data): BlockPrerunArgs => ({
+    fileHandle: data.fileHandle,
+  }))
 
   .output('datasetOptions', (ctx) =>
     ctx.resultPool.getOptions([{
@@ -134,20 +144,16 @@ export const model = BlockModel.create()
   )
 
   .output('targetOptions', (ctx) => {
-    const ref = ctx.args.datasetRef;
+    const ref = ctx.data.datasetRef;
     if (ref === undefined) return undefined;
 
     const isSingleCell = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1].name === 'pl7.app/vdj/scClonotypeKey';
     const sequenceMatchers = [];
-    // const allowedFeatures = ['CDR1', 'CDR2', 'CDR3', 'FR1', 'FR2',
-    //   'FR3', 'FR4', 'VDJRegion'];
-    // for (const feature of allowedFeatures) {
     if (isSingleCell) {
       sequenceMatchers.push({
         axes: [{ anchor: 'main', idx: 1 }],
         name: 'pl7.app/vdj/sequence',
         domain: {
-          // 'pl7.app/vdj/feature': feature,
           'pl7.app/vdj/scClonotypeChain/index': 'primary',
         },
       });
@@ -155,9 +161,7 @@ export const model = BlockModel.create()
       sequenceMatchers.push({
         axes: [{ anchor: 'main', idx: 1 }],
         name: 'pl7.app/vdj/sequence',
-        domain: {
-          // 'pl7.app/vdj/feature': feature,
-        },
+        domain: {},
       });
     }
 
@@ -190,14 +194,8 @@ export const model = BlockModel.create()
       return undefined;
     }
     const cols = ctx.outputs?.resolve('table')?.getPColumns();
-    if (cols === undefined)
-      return undefined;
-
-    return createPlDataTableV2(
-      ctx,
-      cols,
-      ctx.uiState.tableState,
-    );
+    if (cols === undefined) return undefined;
+    return createPlDataTableV2(ctx, cols, ctx.data.tableState);
   })
 
   .output('pf', (ctx) => {
@@ -205,9 +203,7 @@ export const model = BlockModel.create()
       return undefined;
     }
     const cols = ctx.outputs?.resolve('table')?.getPColumns();
-    if (cols === undefined)
-      return undefined;
-
+    if (cols === undefined) return undefined;
     return createPFrameForGraphs(ctx, cols);
   })
 
@@ -216,9 +212,7 @@ export const model = BlockModel.create()
       return undefined;
     }
     const cols = ctx.outputs?.resolve('table')?.getPColumns();
-    if (cols === undefined)
-      return undefined;
-    // Return only sequence column
+    if (cols === undefined) return undefined;
     return cols.find((c) => c.spec.name === 'pl7.app/vdj/sequence'
       && c.spec.axesSpec[0].name === 'pl7.app/vdj/assay/sequenceId')?.spec;
   })
@@ -228,18 +222,15 @@ export const model = BlockModel.create()
       return undefined;
     }
     const cols = ctx.outputs?.resolve('table')?.getPColumns();
-    if (cols === undefined)
-      return undefined;
+    if (cols === undefined) return undefined;
 
     const msaCols = ctx.outputs?.resolve('assayLinkerPframe')?.getPColumns();
     if (!msaCols) return undefined;
 
-    const columns = getColumns(ctx);
-    if (columns === undefined) {
-      return undefined;
-    }
+    const props = getAnchoredClonotypeProps(ctx);
+    if (!props) return undefined;
 
-    return createPFrameForGraphs(ctx, [...msaCols, ...cols, ...columns.props]);
+    return createPFrameForGraphs(ctx, [...msaCols, ...cols, ...props]);
   })
 
   .output('emptyClonesInput', (ctx) =>
@@ -250,12 +241,16 @@ export const model = BlockModel.create()
 
   .title(() => 'Immune Assay Data')
 
-  .subtitle((ctx) => ctx.args.customBlockLabel || ctx.args.defaultBlockLabel)
+  .subtitle((ctx) => ctx.data.customBlockLabel || deriveDefaultLabel(ctx.data))
 
   .sections((_ctx) => ([
-    { type: 'link', href: '/', label: 'Main' },
+    { type: 'link' as const, href: '/' as const, label: 'Main' },
   ]))
 
-  .done(2);
+  .done();
+
+export type Platforma = typeof platforma;
+export type BlockOutputs = InferOutputsType<typeof platforma>;
 
 export { getDefaultBlockLabel } from './label';
+export * from './types';

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -22,6 +22,7 @@ import type {
   BlockPrerunArgs,
   LegacyBlockArgs,
   LegacyBlockUiState,
+  Modality,
   Settings,
 } from './types';
 
@@ -52,6 +53,9 @@ const blockDataModel = new DataModelBuilder()
     fileImportError: uiState?.fileImportError,
     tableState: uiState?.tableState ?? createPlDataTableStateV2(),
     alignmentModel: uiState?.alignmentModel ?? {},
+    // Pre-peptide-support projects are always antibody/TCR; seeding this prevents
+    // the modality-reset watcher from clobbering user-tuned thresholds on reopen.
+    lastAppliedModality: 'antibody_tcr',
   }))
   .init(() => ({
     customBlockLabel: '',
@@ -70,6 +74,7 @@ const blockDataModel = new DataModelBuilder()
     fileImportError: undefined,
     tableState: createPlDataTableStateV2(),
     alignmentModel: {},
+    lastAppliedModality: undefined,
   }));
 
 function deriveDefaultLabel(data: BlockData): string {
@@ -100,7 +105,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
     if (data.datasetRef === undefined) throw new Error('Dataset is required');
-    if (data.targetRef === undefined) throw new Error('Target clonotype sequence is required');
+    if (data.targetRef === undefined) throw new Error('Sequence column to match is required');
     if (data.fileHandle === undefined) throw new Error('Assay file is required');
     if (data.importColumns === undefined) throw new Error('Assay file has not been parsed yet');
     if (data.sequenceColumnHeader === undefined) throw new Error('Assay sequence column is required');
@@ -140,22 +145,39 @@ export const platforma = BlockModelV3.create(blockDataModel)
         { name: 'pl7.app/vdj/scClonotypeKey' },
       ],
       annotations: { 'pl7.app/isAnchor': 'true' },
+    }, {
+      axes: [
+        { name: 'pl7.app/sampleId' },
+        { name: 'pl7.app/variantKey' },
+      ],
+      annotations: { 'pl7.app/isAnchor': 'true' },
     }], {}),
   )
+
+  .output('modality', (ctx): Modality | undefined => {
+    if (ctx.data.datasetRef === undefined) return undefined;
+    const spec = ctx.resultPool.getPColumnSpecByRef(ctx.data.datasetRef);
+    if (spec === undefined) return undefined;
+    return spec.axesSpec[1]?.name === 'pl7.app/variantKey' ? 'peptide' : 'antibody_tcr';
+  }, { retentive: true })
 
   .output('targetOptions', (ctx) => {
     const ref = ctx.data.datasetRef;
     if (ref === undefined) return undefined;
 
-    const isSingleCell = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1].name === 'pl7.app/vdj/scClonotypeKey';
+    const datasetAxis = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name;
     const sequenceMatchers = [];
-    if (isSingleCell) {
+    if (datasetAxis === 'pl7.app/variantKey') {
+      sequenceMatchers.push({
+        axes: [{ anchor: 'main', idx: 1 }],
+        name: 'pl7.app/sequence',
+        domain: { 'pl7.app/feature': 'peptide' },
+      });
+    } else if (datasetAxis === 'pl7.app/vdj/scClonotypeKey') {
       sequenceMatchers.push({
         axes: [{ anchor: 'main', idx: 1 }],
         name: 'pl7.app/vdj/sequence',
-        domain: {
-          'pl7.app/vdj/scClonotypeChain/index': 'primary',
-        },
+        domain: { 'pl7.app/vdj/scClonotypeChain/index': 'primary' },
       });
     } else {
       sequenceMatchers.push({
@@ -213,8 +235,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
     }
     const cols = ctx.outputs?.resolve('table')?.getPColumns();
     if (cols === undefined) return undefined;
-    return cols.find((c) => c.spec.name === 'pl7.app/vdj/sequence'
-      && c.spec.axesSpec[0].name === 'pl7.app/vdj/assay/sequenceId')?.spec;
+    return cols.find((c) => c.spec.name === 'pl7.app/sequence'
+      && c.spec.axesSpec[0].name === 'pl7.app/assay/sequenceId')?.spec;
   })
 
   .output('msaPf', (ctx) => {
@@ -239,7 +261,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .output('isRunning', (ctx) => ctx.outputs?.getIsReadyOrError() === false)
 
-  .title(() => 'Immune Assay Data')
+  .title(() => 'Sequence Assay Data')
 
   .subtitle((ctx) => ctx.data.customBlockLabel || deriveDefaultLabel(ctx.data))
 

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -14,6 +14,8 @@ export type Settings = {
   similarityType: 'sequence-identity' | 'alignment-score';
 };
 
+export type Modality = 'antibody_tcr' | 'peptide';
+
 export type ImportColumnInfo = {
   header: string;
   type: 'Int' | 'Double' | 'String';
@@ -39,6 +41,12 @@ export type BlockData = {
   fileImportError?: string;
   tableState: PlDataTableStateV2;
   alignmentModel: PlMultiSequenceAlignmentModel;
+  /**
+   * Last modality the UI applied defaults for. Modality-change reset (R5) fires
+   * only when `outputs.modality` differs from this value, so picking a different
+   * dataset of the same modality preserves user-tuned thresholds.
+   */
+  lastAppliedModality?: Modality;
 };
 
 /** Projected args consumed by the main workflow. */

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -41,11 +41,7 @@ export type BlockData = {
   fileImportError?: string;
   tableState: PlDataTableStateV2;
   alignmentModel: PlMultiSequenceAlignmentModel;
-  /**
-   * Last modality the UI applied defaults for. Modality-change reset (R5) fires
-   * only when `outputs.modality` differs from this value, so picking a different
-   * dataset of the same modality preserves user-tuned thresholds.
-   */
+  // Last modality the UI applied defaults for
   lastAppliedModality?: Modality;
 };
 

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -1,0 +1,93 @@
+import type {
+  ImportFileHandle,
+  PlDataTableStateV2,
+  PlMultiSequenceAlignmentModel,
+  PlRef,
+  SUniversalPColumnId,
+} from '@platforma-sdk/model';
+
+export type Settings = {
+  /** Fraction of aligned residues required (MMseqs2 coverage). */
+  coverageThreshold: number;
+  /** Identity threshold (0-1). */
+  identity: number;
+  similarityType: 'sequence-identity' | 'alignment-score';
+};
+
+export type ImportColumnInfo = {
+  header: string;
+  type: 'Int' | 'Double' | 'String';
+  /** If this column is a sequence column, the type of the sequence. */
+  sequenceType?: 'nucleotide' | 'aminoacid';
+};
+
+/** Unified V3 data: persisted state shaped on the UI's terms. */
+export type BlockData = {
+  customBlockLabel: string;
+  datasetRef?: PlRef;
+  targetRef?: SUniversalPColumnId;
+  fileHandle?: ImportFileHandle;
+  fileExtension?: string;
+  detectedXsvType?: 'csv' | 'tsv';
+  importColumns?: ImportColumnInfo[];
+  sequenceColumnHeader?: string;
+  selectedColumns: string[];
+  settings: Settings;
+  lessSensitive: boolean;
+  mem?: number;
+  cpu?: number;
+  fileImportError?: string;
+  tableState: PlDataTableStateV2;
+  alignmentModel: PlMultiSequenceAlignmentModel;
+};
+
+/** Projected args consumed by the main workflow. */
+export type BlockArgs = {
+  defaultBlockLabel: string;
+  customBlockLabel: string;
+  datasetRef: PlRef;
+  targetRef: SUniversalPColumnId;
+  fileHandle: ImportFileHandle;
+  detectedXsvType?: 'csv' | 'tsv';
+  importColumns: ImportColumnInfo[];
+  sequenceColumnHeader: string;
+  selectedColumns: string[];
+  settings: Settings;
+  lessSensitive: boolean;
+  mem?: number;
+  cpu?: number;
+};
+
+/**
+ * Projected prerun args. Prerun imports `fileHandle` and emits `assayFile` so
+ * the UI can read the file bytes via ReactiveFileContent. The subtemplate
+ * guards undefined, so the projection passes through without throwing.
+ */
+export type BlockPrerunArgs = {
+  fileHandle?: ImportFileHandle;
+};
+
+/** Pre-V3 args shape, frozen snapshot for `upgradeLegacy`. */
+export type LegacyBlockArgs = {
+  defaultBlockLabel: string;
+  customBlockLabel: string;
+  datasetRef?: PlRef;
+  targetRef?: SUniversalPColumnId;
+  fileHandle?: ImportFileHandle;
+  fileExtension?: string;
+  detectedXsvType?: 'csv' | 'tsv';
+  importColumns?: ImportColumnInfo[];
+  sequenceColumnHeader?: string;
+  selectedColumns: string[];
+  settings: Settings;
+  lessSensitive: boolean;
+  mem?: number;
+  cpu?: number;
+};
+
+/** Pre-V3 UI state shape, frozen snapshot for `upgradeLegacy`. */
+export type LegacyBlockUiState = {
+  fileImportError?: string;
+  tableState: PlDataTableStateV2;
+  alignmentModel: PlMultiSequenceAlignmentModel;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.8.0
-      version: 2.8.0
+      specifier: 2.8.2
+      version: 2.8.2
     '@platforma-sdk/blocks-deps-updater':
       specifier: 2.2.0
       version: 2.2.0
@@ -88,7 +88,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       '@platforma-sdk/blocks-deps-updater':
         specifier: 'catalog:'
         version: 2.2.0
@@ -113,7 +113,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
 
   model:
     dependencies:
@@ -135,7 +135,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.27.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.27.0)(typescript@5.6.3))(eslint-plugin-n@17.18.0(eslint@9.27.0))(eslint-plugin-vue@9.33.0(eslint@9.27.0))(eslint@9.27.0)(globals@15.15.0)(typescript-eslint@8.32.1(eslint@9.27.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -1024,6 +1024,10 @@ packages:
     resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
@@ -1032,6 +1036,9 @@ packages:
 
   '@milaboratories/pl-model-backend@1.3.0':
     resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
 
   '@milaboratories/pl-model-common@1.42.0':
     resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
@@ -1382,8 +1389,8 @@ packages:
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3':
     resolution: {integrity: sha512-npV+3LXmQNaX5/QsqtsRr5i0oLG7Uu5p51pI27WA2AbN2iyEUbHwbELhEwU26rkdzKTukCvCzs3NTuxIxQy7vQ==}
 
-  '@platforma-sdk/block-tools@2.8.0':
-    resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
+  '@platforma-sdk/block-tools@2.8.2':
+    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -6963,6 +6970,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.0
 
+  '@milaboratories/pl-client@3.8.1':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.0
+
   '@milaboratories/pl-error-like@1.12.10':
     dependencies:
       json-stringify-safe: 5.0.1
@@ -6975,6 +7000,12 @@ snapshots:
   '@milaboratories/pl-model-backend@1.3.0':
     dependencies:
       '@milaboratories/pl-client': 3.7.0
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    dependencies:
+      '@milaboratories/pl-client': 3.8.1
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -7299,11 +7330,11 @@ snapshots:
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3': {}
 
-  '@platforma-sdk/block-tools@2.8.0':
+  '@platforma-sdk/block-tools@2.8.2':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,17 +13,20 @@ catalogs:
       specifier: ^2.29.8
       version: 2.29.8
     '@milaboratories/graph-maker':
-      specifier: 1.2.8
-      version: 1.2.8
+      specifier: 1.4.2
+      version: 1.4.2
+    '@milaboratories/helpers':
+      specifier: 1.14.2
+      version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
-      specifier: 1.47.4
-      version: 1.47.4
+      specifier: 1.47.12
+      version: 1.47.12
     '@milaboratories/strings':
       specifier: 0.1.2
       version: 0.1.2
     '@milaboratories/ts-builder':
-      specifier: 1.3.2
-      version: 1.3.2
+      specifier: 1.5.0
+      version: 1.5.0
     '@milaboratories/ts-configs':
       specifier: 1.2.3
       version: 1.2.3
@@ -34,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.7.5
-      version: 2.7.5
+      specifier: 2.8.0
+      version: 2.8.0
     '@platforma-sdk/blocks-deps-updater':
       specifier: 2.2.0
       version: 2.2.0
@@ -43,20 +46,20 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.63.1
-      version: 1.63.1
+      specifier: 1.77.4
+      version: 1.77.4
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.5
-      version: 2.5.5
+      specifier: 3.0.0
+      version: 3.0.0
     '@platforma-sdk/ui-vue':
-      specifier: 1.63.1
-      version: 1.63.1
+      specifier: 1.77.4
+      version: 1.77.4
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.11.0
-      version: 5.11.0
+      specifier: 5.25.0
+      version: 5.25.0
     eslint:
       specifier: ^9.25.1
       version: 9.27.0
@@ -85,7 +88,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.5
+        version: 2.8.0
       '@platforma-sdk/blocks-deps-updater':
         specifier: 'catalog:'
         version: 2.2.0
@@ -110,26 +113,29 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.5
+        version: 2.8.0
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.2.8(@milaboratories/pl-model-common@1.31.1)(@platforma-sdk/model@1.63.1)(@platforma-sdk/ui-vue@1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+      '@milaboratories/helpers':
+        specifier: 'catalog:'
+        version: 1.14.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.63.1
+        version: 1.77.4
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.3.2(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
+        version: 1.5.0(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.5
+        version: 2.8.0
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.27.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.27.0)(typescript@5.6.3))(eslint-plugin-n@17.18.0(eslint@9.27.0))(eslint-plugin-vue@9.33.0(eslint@9.27.0))(eslint@9.27.0)(globals@15.15.0)(typescript-eslint@8.32.1(eslint@9.27.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -222,10 +228,10 @@ importers:
         version: 3.2.1
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.2.8(@milaboratories/pl-model-common@1.31.1)(@platforma-sdk/model@1.63.1)(@platforma-sdk/ui-vue@1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.4(@platforma-sdk/model@1.63.1)(@platforma-sdk/ui-vue@1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -234,10 +240,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.63.1
+        version: 1.77.4
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       sass-embedded:
         specifier: 'catalog:'
         version: 1.89.0
@@ -250,7 +256,7 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.3.2(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
+        version: 1.5.0(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
@@ -298,11 +304,11 @@ importers:
         version: 1.18.3
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.11.0
+        version: 5.25.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.5
+        version: 3.0.0
 
 packages:
 
@@ -976,69 +982,65 @@ packages:
   '@milaboratories/biowasm-tools@2.0.2':
     resolution: {integrity: sha512-pe9bIiLni1vMr3tbM87bC2bYRYtwJWeHoZEGAN8WHLRvXW2ouNPvQT5b7LgSsnVtDXsU4L1Eu5cA4W/E94/5tA==}
 
-  '@milaboratories/graph-maker@1.2.8':
-    resolution: {integrity: sha512-jwxtQzLP1VvRmW2X2oQRPmDVK67uNDJ3K0T8HV5dHOckIwRW6MD86CHwwle4RuD2L2onWI2/KWoXWaUOOzpt6w==}
+  '@milaboratories/graph-maker@1.4.2':
+    resolution: {integrity: sha512-MIGMuVsT7QisCJNBCzXYqfBDQ5rjLpEbP8xeUoL23KKi/MjKeg/S2Srn/znWcTFtOFYdWOQjaPoaqcCEKvvICg==}
     peerDependencies:
-      '@platforma-sdk/model': ^1.61.1
-      '@platforma-sdk/ui-vue': ^1.61.1
+      '@platforma-sdk/model': 1.73.3
+      '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/helpers@1.14.0':
-    resolution: {integrity: sha512-lKzbuUJHBiGEVxqS9+EaYkuMAQt0iAohQUiIviu+2rNZHrTIvJGLBIiLBHC7fmjJM45xCKzyLG6c0tPjDUi2kQ==}
+  '@milaboratories/helpers@1.14.2':
+    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/helpers@1.14.1':
-    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
-    engines: {node: '>=22'}
+  '@milaboratories/miplots4@1.2.0':
+    resolution: {integrity: sha512-tUJkqB6yCj/HxSrxWvmiCulluPwhIy1538e93cz/P9t2OqAXCumkyGbXwNKwwSRxitiVVjqG26rZbMQBctykdA==}
 
-  '@milaboratories/miplots4@1.0.176':
-    resolution: {integrity: sha512-PT2kw5H+YVYR8RNp4SOeP8Pi+sEbnptDQYsQYnwAhjNqfLjBG2kFvDeIXTrULPMW2L1L+hKwdRcEpDrO1ysUKg==}
-
-  '@milaboratories/miplots4@1.0.178':
-    resolution: {integrity: sha512-JC87s75OaPALWw/vTOQ/CIRk/tIkngQs4KeeWqtVYwOGtzjD5Gc+AvGXfkeR2VTQCqX1EebwBRG+3sw/YodTDw==}
-
-  '@milaboratories/multi-sequence-alignment@1.47.4':
-    resolution: {integrity: sha512-/EwJKV7GDEWeM/aqYgGQXyc553oJkOtHhMQPTDdAQlBZG10oh4Ydx742CDks5gObmb5Hh4ViHDZPEcGleMGwKw==}
+  '@milaboratories/multi-sequence-alignment@1.47.12':
+    resolution: {integrity: sha512-K0blTkxdxEi1ZWrTUAlSpqqBK9Kj2rZvs8SX+p56p9Z6bjg6CAZa3PYC7zCgggwZamP+S0rTziuha9W9cWZwUw==}
     peerDependencies:
-      '@platforma-sdk/model': ^1.57.2
-      '@platforma-sdk/ui-vue': ^1.57.3
+      '@platforma-sdk/model': 1.73.3
+      '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-plots@1.1.69':
-    resolution: {integrity: sha512-ByeCqlRhZsNuPJcJ6aWahQ1joPydHcb6+mgDKHKWYYE+rz+6Lw9JXjxK8sFHslKMAVbvysCoIWXjgZzn5oFpAQ==}
+  '@milaboratories/pf-plots@1.4.1':
+    resolution: {integrity: sha512-qcJ/vzZLtxBi4mPGAvM1vQuBZfC2YYHLTTkJbsJUeWwfOjQg/YEuxoHkN58LXHnd6s0pcc7clAtpwdq0Y8JONQ==}
     peerDependencies:
-      '@milaboratories/pl-model-common': ^1.29.0
-      '@platforma-sdk/model': ^1.61.1
+      '@milaboratories/pl-model-common': 1.39.0
+      '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.2.3':
-    resolution: {integrity: sha512-5CtJnO9kibQRwF1JLeyQKEyKSmsvR21YPtO9c+BN2+VR+S7Vkep7EexA9s/J7rC84IVqsrn0Yavn9c8D4a7v0g==}
+  '@milaboratories/pf-spec-driver@1.3.17':
+    resolution: {integrity: sha512-ShmOxNr8ocgZJiOaSC1bD23L1+oqwiaPS5Hh8Bqa9FO1FP7DWPMWV0LtVuUr7ZRGLzivjh9ccQbMyK9QuP5pbg==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.17':
-    resolution: {integrity: sha512-/4UVIp6ZxfZlMPTozf74Sw4/3O2XxRf+NYWG1Y4SR1YZj61coq69iDe2h/i6/jrFUNfu1jf6ITeH9V3X3Zf2fA==}
+  '@milaboratories/pframes-rs-wasip2@1.1.35':
+    resolution: {integrity: sha512-kcR9YLWAbKYSpksPOoJWkcrkSiUUAEKj/Wuyc9aFsd2bNbWcIb7mLGptFOuvhLn07bZHn0oNcVgupEqd/6Ftbw==}
+
+  '@milaboratories/pframes-rs-wasm@1.1.35':
+    resolution: {integrity: sha512-wmnEujKa47y+CguYFbeYPjzYAsdhOQO/oNKIyCl0cG/RDwi3qtioKj6DMIBQgjC+/yLPuMsPkjXh7aaPn9cvpA==}
     peerDependencies:
-      '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.28.0
-      '@milaboratories/pl-model-middle-layer': 1.15.0
+      '@bytecodealliance/preview2-shim': 0.17.9
+      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@2.18.5':
-    resolution: {integrity: sha512-ltz/e14h9g693cfwJPkK3N930GV9G92YL82HRbeopRE3SrVYQuarAHXY6LA7zo7Fus/g4x1vP5db98E0L39eqw==}
+  '@milaboratories/pl-client@3.7.0':
+    resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-error-like@1.12.9':
-    resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-model-backend@1.2.5':
-    resolution: {integrity: sha512-kOgETSiHte0HiRqY7Z8vdoj1dEMzxS/lDvDwVOS+Dr4lvx0WVtwbo9eq/ymrNYW+iG/HEemIe6lzTjhGXaw38A==}
+  '@milaboratories/pl-model-backend@1.3.0':
+    resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
 
-  '@milaboratories/pl-model-common@1.31.1':
-    resolution: {integrity: sha512-MLQvhXXFOykABZr8aVgzt5x0htT7ye4cvvnVy0TgOITXpct+lEmWvaVj29zirK/0VFw7wnTXDGnLwusr77NZFA==}
+  '@milaboratories/pl-model-common@1.42.0':
+    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.16.3':
-    resolution: {integrity: sha512-XLZEC3POgUMNNjXr3Pudh7gx2CXZygeskxuQCyPfj4c8Fi35+kAfH9VBpNZD1koiT2n+x5QZyS3RpzcAddQTnQ==}
+  '@milaboratories/pl-model-middle-layer@1.20.0':
+    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
 
-  '@milaboratories/ptabler-expression-js@1.2.5':
-    resolution: {integrity: sha512-pxBFYycBAVc4pVCo+qDzi2mQDQiar5D2tOnkWjSLgo13OAY+KVDYQJeD4KUt2DCocMy0Uo+lREZpU1bvVBqH3A==}
+  '@milaboratories/ptabler-expression-js@1.2.25':
+    resolution: {integrity: sha512-dFx+gNoDssA7dQZTr0y93TWuNwlyNY9tzvUaeH0F7BYu/03ZzyLZ4N2iM7ai44bisqAe9o0ppmNM9LtoeTn5Gg==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1054,22 +1056,22 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.3.2':
-    resolution: {integrity: sha512-UOCJZAN4F7q0e9nh500a0KdQcP2qnXU0jPKvhOIzm//zMMr8q2J2I7Q6HIxqyJzEKxgCak3usFS5D0QP1Oow2w==}
+  '@milaboratories/ts-builder@1.5.0':
+    resolution: {integrity: sha512-tSLwqZ5dfmiXwriCYh2LI++N3AfB2RR5E30TSQRYd1ovC9fMZ9eGCZ3WskQ1h0p5+dUeSKGkDlgZFNF1wO1TTQ==}
     hasBin: true
 
   '@milaboratories/ts-configs@1.2.3':
     resolution: {integrity: sha512-NALtuzTbSzAz2Uk7X1sWq3rBo4XAV/vAQ1Mf7IfiNiv1euZ+0+TF0NDJMNiEcU6BT/Q55dATSKhIY2r680ljXw==}
 
-  '@milaboratories/ts-helpers-oclif@1.1.40':
-    resolution: {integrity: sha512-0I5vpgfUYT0sfADFTy5iVeCNPPBnJcZzd6enmbxYp2YczV1EdPDVhv+BbLIN3oLLMKpADJJ485QEXhN2i39Yvg==}
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
 
-  '@milaboratories/ts-helpers@1.8.1':
-    resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
+  '@milaboratories/ts-helpers@1.8.2':
+    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.11.6':
-    resolution: {integrity: sha512-h6XppmjFLnhGUjeDbCRhRqgipmNqXLty6kVY9pg75sSlFQuSSuMRHPzD7FT/N9KSn9Cx3eMDDl09ArALCQkGAQ==}
+  '@milaboratories/uikit@2.14.11':
+    resolution: {integrity: sha512-6I20gxijl8AKIZFWDItWs6cut+v3G0sN3uOhUVTrRW8V77B+f/8e8+HKs+b9F/r5QQ0xP6nJN2nuO+a/EblZcw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1217,43 +1219,117 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/darwin-arm64@1.43.0':
-    resolution: {integrity: sha512-C/GhObv/pQZg34NOzB6Mk8x0wc9AKj8fXzJF8ZRKTsBPyHusC6AZ6bba0QG0TUufw1KWuD0j++oebQfWeiFXNw==}
+  '@oxlint/binding-android-arm-eabi@1.63.0':
+    resolution: {integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.63.0':
+    resolution: {integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.63.0':
+    resolution: {integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/darwin-x64@1.43.0':
-    resolution: {integrity: sha512-4NjfUtEEH8ewRQ2KlZGmm6DyrvypMdHwBnQT92vD0dLScNOQzr0V9O8Ua4IWXdeCNl/XMVhAV3h4/3YEYern5A==}
+  '@oxlint/binding-darwin-x64@1.63.0':
+    resolution: {integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/linux-arm64-gnu@1.43.0':
-    resolution: {integrity: sha512-75tf1HvwdZ3ebk83yMbSB+moAEWK98mYqpXiaFAi6Zshie7r+Cx5PLXZFUEqkscenoZ+fcNXakHxfn94V6nf1g==}
+  '@oxlint/binding-freebsd-x64@1.63.0':
+    resolution: {integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
+    resolution: {integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
+    resolution: {integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    resolution: {integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-arm64-musl@1.43.0':
-    resolution: {integrity: sha512-BHV4fb36T2p/7bpA9fiJ5ayt7oJbiYX10nklW5arYp4l9/9yG/FQC5J4G1evzbJ/YbipF9UH0vYBAm5xbqGrvw==}
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    resolution: {integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@oxlint/linux-x64-gnu@1.43.0':
-    resolution: {integrity: sha512-1l3nvnzWWse1YHibzZ4HQXdF/ibfbKZhp9IguElni3bBqEyPEyurzZ0ikWynDxKGXqZa+UNXTFuU1NRVX1RJ3g==}
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    resolution: {integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    resolution: {integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    resolution: {integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    resolution: {integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    resolution: {integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/linux-x64-musl@1.43.0':
-    resolution: {integrity: sha512-+jNYgLGRFTJxJuaSOZJBwlYo5M0TWRw0+3y5MHOL4ArrIdHyCthg6r4RbVWrsR1qUfUE1VSSHQ2bfbC99RXqMg==}
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    resolution: {integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@oxlint/win32-arm64@1.43.0':
-    resolution: {integrity: sha512-dvs1C/HCjCyGTURMagiHprsOvVTT3omDiSzi5Qw0D4QFJ1pEaNlfBhVnOUYgUfS6O7Mcmj4+G+sidRsQcWQ/kA==}
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    resolution: {integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    resolution: {integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/win32-x64@1.43.0':
-    resolution: {integrity: sha512-bSuItSU8mTSDsvmmLTepTdCL2FkJI6dwt9tot/k0EmiYF+ArRzmsl4lXVLssJNRV5lJEc5IViyTrh7oiwrjUqA==}
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    resolution: {integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
+    resolution: {integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -1279,35 +1355,35 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3@1.7.7':
     resolution: {integrity: sha512-1aJmPOS+XaArKUriwu34LfDrcf4/JQDLtCLm0O05hYAepJ/xMVJUHFeJ3rbp7QloejfD51475THhLXQWj5KB+g==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.14.5':
-    resolution: {integrity: sha512-WZgX43fFYAbf6wWawN9edpBQm3ldtk9SrrfPvLPEmYiYyytjcxgEJrCeRiFv1rUkhOHpCyr7HSR4yonHh6W+fQ==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.9':
+    resolution: {integrity: sha512-DtCxrXCaDzjRzEPhlbnJnLfTQatHnGau72D/b8nUtxIgGTNZXG9S3WfRS+VgtaITETbh1x78k4/Qi1o5hUPQHQ==}
 
-  '@platforma-open/milaboratories.software-ptabler@1.15.0':
-    resolution: {integrity: sha512-7hbuOsIU3WsmAsBwWoVfP1UyZPBQj/Ec8KGoUBoaAq5VNjVQ7oQR3Nx4co+dIJJ9+cEB3c633Xx1DNxebb5uNQ==}
+  '@platforma-open/milaboratories.software-ptabler@1.16.1':
+    resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.9':
-    resolution: {integrity: sha512-pCg5NZREkrzBqx7jXv14MQMGWh2nfB9JJMn4MoF0lYJjLGkXpyFyYSVErW8IIvbNHcFLE5tU1pG7zilP/wSPvg==}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
+    resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.5':
-    resolution: {integrity: sha512-CqlJEDZGmSdamYthPo9jQB6teYVGOs16I8P5eQE+AUVYCGXr0kxrk316CTsegPsg1gxhdw1I0FwljNOloVrIgA==}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7':
+    resolution: {integrity: sha512-CqXbfFld2l6Y/8rtcZXRPsa5kqNnaS3QWUxrcfMYwNxultbhLzjZGdqSR7ejV9xRWilXpeg6DdZJIKF3+KDH8g==}
 
-  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.3':
-    resolution: {integrity: sha512-hrY/UoOUtqyRtEV20h12GvHH5WlixcbyK5SVHJjj1q3ewvM2svo25bADK0cKsopzwFBkzZU984fpy9evpBeBzg==}
+  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5':
+    resolution: {integrity: sha512-ZdVg77pZ0Hgvxdk+mYahEyPbcTzDyz6Y7qlm6A0rJw8WCYmDVkfLqctQj0QkTLHM76oSWOHJIgD07ZxORjjgwA==}
 
-  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.3':
-    resolution: {integrity: sha512-1PCVZaOiEWkv9g2XZDdR6UPGS28mV/PPMVeIxTr5FOR9/ibfX29rohOClxRZIFqKgGN+/vH/GxKrk3aU2jTRUg==}
+  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5':
+    resolution: {integrity: sha512-x6WOZ8S3uLXzmwliCF500hw7VQ4A9U3VBbESjJlPia26aU91FqB3ylKyH2fEyTiVw2wADlTYuui1tHX47iS5Lw==}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.2':
-    resolution: {integrity: sha512-/ViK6kJDjCL/0jBFuEqLwSrpLK4afnR4XiHFOvIlaiYgWHeRU4Gw3aCSMRo6lhG3r6YeeWBqZ9FCkGKKy3TPvg==}
+  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+    resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3':
     resolution: {integrity: sha512-npV+3LXmQNaX5/QsqtsRr5i0oLG7Uu5p51pI27WA2AbN2iyEUbHwbELhEwU26rkdzKTukCvCzs3NTuxIxQy7vQ==}
 
-  '@platforma-sdk/block-tools@2.7.5':
-    resolution: {integrity: sha512-PB8cMAzcXfWO9lV/KVE1vcoRoMDESnZt4IlObSL3+vpwSZWB4oLlv3TbrYpXz0dPni/Bmi9bMXwDOXhksuob9w==}
+  '@platforma-sdk/block-tools@2.8.0':
+    resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1326,23 +1402,23 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.63.1':
-    resolution: {integrity: sha512-Ma1PEz3yZw6Jbo23BEUrZcO/8q15FU0DEtcjxObobVqXFoS0o4yCNPDxWytksiT2JL3G8F+Ic+k/wHYZ/Fbd0Q==}
+  '@platforma-sdk/model@1.77.4':
+    resolution: {integrity: sha512-YJ/IsURqdaNnOf9JNw8dfmwaZQz1JhEqqR76jK7tmEH7y5ZOKB8mc5Hp3A/x7Wp/9JcXLAVY84h8s6R86FPl4w==}
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.5':
-    resolution: {integrity: sha512-bbTXHiJ6uTh2ECdMWjblKWI6C3bPJw3LZbYp1VsqRiyVBNOy0PH3X3hfIbCGKtDVS3/ZIMpgtzalWr9jqNUrPQ==}
+  '@platforma-sdk/tengo-builder@3.0.0':
+    resolution: {integrity: sha512-HfKoCZLHKwfdgwXqpYcp/gBxrFix5C8BJfkwSybZ3XNvFMcl+gvvwhFfmOwwY+TEcbiqNx21Z1GPFD5prY3g/A==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/ui-vue@1.63.1':
-    resolution: {integrity: sha512-YTiixsJjzhdiI+M+DwEmSpHlTIXUDZ39FKA/LKrP0hiBOQo7+bpzg+hkOvWbDbvQUlwMwrVqTuyY994PGElPgQ==}
+  '@platforma-sdk/ui-vue@1.77.4':
+    resolution: {integrity: sha512-7P0+OGqu/BMhuvSqeEi/aBrrA9yCGPhs6jmcJlnP/rqCtwz2+M/CTvaYji7zI5U1htpiN877DdfKezdWUj43oA==}
 
-  '@platforma-sdk/workflow-tengo@5.11.0':
-    resolution: {integrity: sha512-+jH4xSqWABB6DCKFvfWrUVYuoBwWrfNObGi9a1zSWvAQZFw++V5nlJLG0nfdoTNnCXiXBl+9nseMenjDBMM6kg==}
+  '@platforma-sdk/workflow-tengo@5.25.0':
+    resolution: {integrity: sha512-uLRwbgq7tHUVtQ+y+iVe40Cf2S9ept8+Q0dBGVlegvxsAqQPOQxhQkkHYvbH6zLmaf237bISME1rL1MxRs2ujQ==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -3464,20 +3540,11 @@ packages:
   '@vitest/utils@4.0.12':
     resolution: {integrity: sha512-DVS/TLkLdvGvj1avRy0LSmKfrcI9MNFvNGN6ECjTUHWJdlcgPDOXhjMis5Dh7rBH62nAmSXnkPbE+DZ5YD75Rw==}
 
-  '@volar/language-core@2.4.14':
-    resolution: {integrity: sha512-X6beusV0DvuVseaOEy7GoagS4rYHgDHnTrdOj5jeUb49fW5ceQyP9Ej5rBhqgz2wJggl+2fDbbojq1XKaxDi6w==}
-
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
 
-  '@volar/source-map@2.4.14':
-    resolution: {integrity: sha512-5TeKKMh7Sfxo8021cJfmBzcjfY1SsXsPMMjMvjY7ivesdnybqqS+GxGAoXHAOUawQTwtdUxgP65Im+dEmvWtYQ==}
-
   '@volar/source-map@2.4.28':
     resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
-
-  '@volar/typescript@2.4.14':
-    resolution: {integrity: sha512-p8Z6f/bZM3/HyCdRNFZOEEzts51uV8WHeN8Tnfnm2EBv6FDB2TQLzfVx7aJvnl8ofKAOnS64B2O8bImBFaauRw==}
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
@@ -4373,6 +4440,9 @@ packages:
     resolution: {integrity: sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==}
     engines: {node: '>= 4'}
 
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   immutable@5.1.2:
     resolution: {integrity: sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==}
 
@@ -4771,12 +4841,16 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint@1.43.0:
-    resolution: {integrity: sha512-xiqTCsKZch+R61DPCjyqUVP2MhkQlRRYxLRBeBDi+dtQJ90MOgdcjIktvDCgXz0bgtx94EQzHEndsizZjMX2OA==}
+  oxlint-plugin-eslint@1.63.0:
+    resolution: {integrity: sha512-mb3mlDkQTIzQm0TWvW1n13srNKek3mc4fWNaGsveITlIkKMOi8499rT5B2ZFQDw2+G3LKvjNYkUKIt+OfECqPw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxlint@1.63.0:
+    resolution: {integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.11.2'
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
@@ -5455,6 +5529,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   varint@6.0.0:
@@ -5716,11 +5791,11 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.25.30:
     resolution: {integrity: sha512-VolhdEtu6TJr/fzGuHA/SZ5ixvXqA6ADOG9VRcQ3rdOKmF5hkmcJbyaQjUH5BgmpA9gej++zYRX7zjSmdReIwA==}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
@@ -6763,14 +6838,14 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.2': {}
 
-  '@milaboratories/graph-maker@1.2.8(@milaboratories/pl-model-common@1.31.1)(@platforma-sdk/model@1.63.1)(@platforma-sdk/ui-vue@1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
-      '@milaboratories/helpers': 1.14.0
-      '@milaboratories/miplots4': 1.0.178(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.1.69(@milaboratories/pl-model-common@1.31.1)(@platforma-sdk/model@1.63.1)
-      '@platforma-sdk/model': 1.63.1
-      '@platforma-sdk/ui-vue': 1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
+      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.24(typescript@5.6.3))
@@ -6787,11 +6862,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/helpers@1.14.0': {}
+  '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/helpers@1.14.1': {}
-
-  '@milaboratories/miplots4@1.0.176(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
+  '@milaboratories/miplots4@1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
       '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
       '@d3fc/d3fc-pointer': 3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)
@@ -6829,87 +6902,55 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/miplots4@1.0.178(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
-    dependencies:
-      '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-pointer': 3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)
-      '@d3fc/d3fc-series': 6.1.3(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
-      '@d3fc/d3fc-webgl': 3.2.1(d3-scale@4.0.2)(d3-shape@3.2.0)
-      '@stdlib/stats-anova1': 0.2.2
-      '@stdlib/stats-base-dists-f-cdf': 0.2.2
-      '@stdlib/stats-kruskal-test': 0.2.2
-      '@stdlib/stats-ttest': 0.2.2
-      '@stdlib/stats-ttest2': 0.2.2
-      '@stdlib/stats-wilcoxon': 0.2.2
-      comlink: 4.4.2
-      d3-array: 3.2.4
-      d3-axis: 3.0.0
-      d3-color: 3.1.0
-      d3-drag: 3.0.0
-      d3-format: 3.1.0
-      d3-hierarchy: 3.1.2
-      d3-polygon: 3.0.1
-      d3-quadtree: 3.0.1
-      d3-random: 3.0.1
-      d3-scale: 4.0.2
-      d3-selection: 3.0.0
-      d3-shape: 3.2.0
-      d3-zoom: 3.0.0
-      kdbush: 4.0.2
-      lodash: 4.17.21
-      rbush: 4.0.1
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      zod: 3.25.30
-    transitivePeerDependencies:
-      - d3-dispatch
-      - d3-path
-      - d3-scale-chromatic
-      - supports-color
-
-  '@milaboratories/multi-sequence-alignment@1.47.4(@platforma-sdk/model@1.63.1)(@platforma-sdk/ui-vue@1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.2
-      '@milaboratories/miplots4': 1.0.176(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@platforma-sdk/model': 1.63.1
-      '@platforma-sdk/ui-vue': 1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
+      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.24(typescript@5.6.3)
     transitivePeerDependencies:
+      - '@milaboratories/pl-model-common'
       - d3-dispatch
       - d3-path
       - d3-scale-chromatic
       - supports-color
       - typescript
 
-  '@milaboratories/pf-plots@1.1.69(@milaboratories/pl-model-common@1.31.1)(@platforma-sdk/model@1.63.1)':
+  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)':
     dependencies:
-      '@milaboratories/pl-model-common': 1.31.1
-      '@platforma-sdk/model': 1.63.1
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
+      '@platforma-sdk/model': 1.77.4
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.2.3(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-wasm': 1.1.17(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.31.1)(@milaboratories/pl-model-middle-layer@1.16.3)
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/pl-model-middle-layer': 1.16.3
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-wasm@1.1.17(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.31.1)(@milaboratories/pl-model-middle-layer@1.16.3)':
+  '@milaboratories/pframes-rs-wasip2@1.1.35': {}
+
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/pl-model-middle-layer': 1.16.3
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
 
-  '@milaboratories/pl-client@2.18.5':
+  '@milaboratories/pl-client@3.7.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -6922,39 +6963,39 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.0
 
-  '@milaboratories/pl-error-like@1.12.9':
+  '@milaboratories/pl-error-like@1.12.10':
     dependencies:
       json-stringify-safe: 5.0.1
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@milaboratories/pl-http@1.2.4':
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-model-backend@1.2.5':
+  '@milaboratories/pl-model-backend@1.3.0':
     dependencies:
-      '@milaboratories/pl-client': 2.18.5
+      '@milaboratories/pl-client': 3.7.0
       canonicalize: 2.1.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.31.1':
+  '@milaboratories/pl-model-common@1.42.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.16.3':
+  '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.31.1
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.42.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.5':
+  '@milaboratories/ptabler-expression-js@1.2.25':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.14.5
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.9
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -6964,14 +7005,15 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.3.2(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)':
+  '@milaboratories/ts-builder@1.5.0(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.6(vite@8.0.10(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.0))(vue@3.5.24(typescript@5.6.3))
       commander: 12.1.0
       jsonc-parser: 3.3.1
       oxfmt: 0.35.0
-      oxlint: 1.43.0
+      oxlint: 1.63.0
+      oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.17
       rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
@@ -7006,21 +7048,21 @@ snapshots:
 
   '@milaboratories/ts-configs@1.2.3': {}
 
-  '@milaboratories/ts-helpers-oclif@1.1.40':
+  '@milaboratories/ts-helpers-oclif@1.1.41':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.3.0
 
-  '@milaboratories/ts-helpers@1.8.1':
+  '@milaboratories/ts-helpers@1.8.2':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.11.6(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.11(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@platforma-sdk/model': 1.63.1
+      '@milaboratories/helpers': 1.14.2
+      '@platforma-sdk/model': 1.77.4
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -7154,28 +7196,61 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.35.0':
     optional: true
 
-  '@oxlint/darwin-arm64@1.43.0':
+  '@oxlint/binding-android-arm-eabi@1.63.0':
     optional: true
 
-  '@oxlint/darwin-x64@1.43.0':
+  '@oxlint/binding-android-arm64@1.63.0':
     optional: true
 
-  '@oxlint/linux-arm64-gnu@1.43.0':
+  '@oxlint/binding-darwin-arm64@1.63.0':
     optional: true
 
-  '@oxlint/linux-arm64-musl@1.43.0':
+  '@oxlint/binding-darwin-x64@1.63.0':
     optional: true
 
-  '@oxlint/linux-x64-gnu@1.43.0':
+  '@oxlint/binding-freebsd-x64@1.63.0':
     optional: true
 
-  '@oxlint/linux-x64-musl@1.43.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.63.0':
     optional: true
 
-  '@oxlint/win32-arm64@1.43.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.63.0':
     optional: true
 
-  '@oxlint/win32-x64@1.43.0':
+  '@oxlint/binding-linux-arm64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.63.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.63.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.63.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.63.0':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -7199,40 +7274,41 @@ snapshots:
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.4.4
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.5
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.14.5':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.9':
     dependencies:
-      '@milaboratories/pl-model-common': 1.31.1
+      '@milaboratories/pl-model-common': 1.42.0
 
-  '@platforma-open/milaboratories.software-ptabler@1.15.0': {}
+  '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.9': {}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.5': {}
+  '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.3': {}
+  '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5': {}
 
-  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.3': {}
+  '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5': {}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.2':
+  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
     dependencies:
-      '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.5
-      '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.9
-      '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.3
-      '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.3
+      '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.7
+      '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.10
+      '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
+      '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3': {}
 
-  '@platforma-sdk/block-tools@2.7.5':
+  '@platforma-sdk/block-tools@2.8.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/pl-model-middle-layer': 1.16.3
+      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.1
-      '@milaboratories/ts-helpers-oclif': 1.1.40
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
       '@oclif/core': 4.3.0
       '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0
@@ -7241,7 +7317,7 @@ snapshots:
       tar: 7.4.3
       undici: 7.16.0
       yaml: 2.8.0
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - aws-crt
 
@@ -7260,18 +7336,18 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.32.1(eslint@9.27.0)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.63.1':
+  '@platforma-sdk/model@1.77.4':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/pl-model-middle-layer': 1.16.3
-      '@milaboratories/ptabler-expression-js': 1.2.5
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@platforma-sdk/package-builder@3.12.0':
     dependencies:
@@ -7289,21 +7365,21 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@2.5.5':
+  '@platforma-sdk/tengo-builder@3.0.0':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.5
+      '@milaboratories/pl-model-backend': 1.3.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.1
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.3.0
       winston: 3.17.0
 
-  '@platforma-sdk/ui-vue@1.63.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.2.3(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.31.1
-      '@milaboratories/uikit': 2.11.6(typescript@5.6.3)
-      '@platforma-sdk/model': 1.63.1
+      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/uikit': 2.14.11(typescript@5.6.3)
+      '@platforma-sdk/model': 1.77.4
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -7315,9 +7391,10 @@ snapshots:
       d3-format: 3.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
+      immer: 11.1.4
       lru-cache: 11.2.2
       vue: 3.5.24(typescript@5.6.3)
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
       - async-validator
@@ -7333,12 +7410,13 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.11.0':
+  '@platforma-sdk/workflow-tengo@5.25.0':
     dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 1.15.0
+      '@platforma-open/milaboratories.software-ptabler': 1.16.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.0.2
+      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
     dependencies:
@@ -7432,7 +7510,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.55.1
 
@@ -7440,7 +7518,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.55.1
 
@@ -10184,23 +10262,11 @@ snapshots:
       '@vitest/pretty-format': 4.0.12
       tinyrainbow: 3.0.3
 
-  '@volar/language-core@2.4.14':
-    dependencies:
-      '@volar/source-map': 2.4.14
-
   '@volar/language-core@2.4.28':
     dependencies:
       '@volar/source-map': 2.4.28
 
-  '@volar/source-map@2.4.14': {}
-
   '@volar/source-map@2.4.28': {}
-
-  '@volar/typescript@2.4.14':
-    dependencies:
-      '@volar/language-core': 2.4.14
-      path-browserify: 1.0.1
-      vscode-uri: 3.1.0
 
   '@volar/typescript@2.4.28':
     dependencies:
@@ -10245,7 +10311,7 @@ snapshots:
 
   '@vue/language-core@2.2.0(typescript@5.9.3)':
     dependencies:
-      '@volar/language-core': 2.4.14
+      '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.24
       '@vue/compiler-vue2': 2.7.16
       '@vue/shared': 3.5.24
@@ -10912,7 +10978,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.7
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
 
@@ -10951,10 +11017,6 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
-
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -11108,6 +11170,8 @@ snapshots:
   ignore@5.3.2: {}
 
   ignore@7.0.4: {}
+
+  immer@11.1.4: {}
 
   immutable@5.1.2: {}
 
@@ -11467,16 +11531,29 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.35.0
       '@oxfmt/binding-win32-x64-msvc': 0.35.0
 
-  oxlint@1.43.0:
+  oxlint-plugin-eslint@1.63.0: {}
+
+  oxlint@1.63.0:
     optionalDependencies:
-      '@oxlint/darwin-arm64': 1.43.0
-      '@oxlint/darwin-x64': 1.43.0
-      '@oxlint/linux-arm64-gnu': 1.43.0
-      '@oxlint/linux-arm64-musl': 1.43.0
-      '@oxlint/linux-x64-gnu': 1.43.0
-      '@oxlint/linux-x64-musl': 1.43.0
-      '@oxlint/win32-arm64': 1.43.0
-      '@oxlint/win32-x64': 1.43.0
+      '@oxlint/binding-android-arm-eabi': 1.63.0
+      '@oxlint/binding-android-arm64': 1.63.0
+      '@oxlint/binding-darwin-arm64': 1.63.0
+      '@oxlint/binding-darwin-x64': 1.63.0
+      '@oxlint/binding-freebsd-x64': 1.63.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.63.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.63.0
+      '@oxlint/binding-linux-arm64-gnu': 1.63.0
+      '@oxlint/binding-linux-arm64-musl': 1.63.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.63.0
+      '@oxlint/binding-linux-riscv64-musl': 1.63.0
+      '@oxlint/binding-linux-s390x-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-gnu': 1.63.0
+      '@oxlint/binding-linux-x64-musl': 1.63.0
+      '@oxlint/binding-openharmony-arm64': 1.63.0
+      '@oxlint/binding-win32-arm64-msvc': 1.63.0
+      '@oxlint/binding-win32-ia32-msvc': 1.63.0
+      '@oxlint/binding-win32-x64-msvc': 1.63.0
 
   p-filter@2.1.0:
     dependencies:
@@ -12003,8 +12080,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -12110,7 +12187,7 @@ snapshots:
     dependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@24.5.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@volar/typescript': 2.4.14
+      '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
       debug: 4.4.3(supports-color@8.1.1)
@@ -12146,11 +12223,11 @@ snapshots:
   vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(sass-embedded@1.89.0)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.10
       rollup: 4.55.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.5.2
       fsevents: 2.3.3
@@ -12327,8 +12404,8 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod@3.23.8: {}
-
   zod@3.25.30: {}
+
+  zod@3.25.76: {}
 
   zod@4.1.12: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.77.4
   '@platforma-sdk/tengo-builder': 3.0.0
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.0
+  '@platforma-sdk/block-tools': 2.8.2
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.77.4
   '@milaboratories/helpers': 1.14.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,19 +15,19 @@ packages:
 
 catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
-  '@milaboratories/ts-builder': 1.3.2
+  '@milaboratories/ts-builder': 1.5.0
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 5.11.0
-  '@platforma-sdk/model': 1.63.1
-  '@platforma-sdk/ui-vue': 1.63.1
-  '@platforma-sdk/tengo-builder': 2.5.5
+  '@platforma-sdk/workflow-tengo': 5.25.0
+  '@platforma-sdk/model': 1.77.4
+  '@platforma-sdk/ui-vue': 1.77.4
+  '@platforma-sdk/tengo-builder': 3.0.0
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.7.5
+  '@platforma-sdk/block-tools': 2.8.0
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.61.1
-  '@milaboratories/helpers': 1.14.0
-  '@milaboratories/graph-maker': 1.2.8
-  '@milaboratories/multi-sequence-alignment': 1.47.4
+  '@platforma-sdk/test': 1.77.4
+  '@milaboratories/helpers': 1.14.2
+  '@milaboratories/graph-maker': 1.4.2
+  '@milaboratories/multi-sequence-alignment': 1.47.12
   '@milaboratories/strings': 0.1.2
   "@platforma-sdk/blocks-deps-updater": 2.2.0
 

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -1,14 +1,8 @@
-import { getDefaultBlockLabel, model } from '@platforma-open/milaboratories.immune-assay-data.model';
-import { getFileNameFromHandle } from '@platforma-sdk/model';
-import { defineApp } from '@platforma-sdk/ui-vue';
-import { watchEffect } from 'vue';
+import { platforma } from '@platforma-open/milaboratories.immune-assay-data.model';
+import { defineAppV3 } from '@platforma-sdk/ui-vue';
 import MainPage from './pages/MainPage.vue';
 
-export const sdkPlugin = defineApp(model, (app) => {
-  app.model.args.customBlockLabel ??= '';
-
-  syncDefaultBlockLabel(app.model);
-
+export const sdkPlugin = defineAppV3(platforma, () => {
   return {
     routes: {
       '/': () => MainPage,
@@ -17,20 +11,3 @@ export const sdkPlugin = defineApp(model, (app) => {
 });
 
 export const useApp = sdkPlugin.useApp;
-
-type AppModel = ReturnType<typeof useApp>['model'];
-
-function syncDefaultBlockLabel(model: AppModel) {
-  watchEffect(() => {
-    const fileName = model.args.fileHandle
-      ? getFileNameFromHandle(model.args.fileHandle)
-      : undefined;
-
-    model.args.defaultBlockLabel = getDefaultBlockLabel({
-      fileName,
-      similarityType: model.args.settings.similarityType,
-      identity: model.args.settings.identity,
-      coverageThreshold: model.args.settings.coverageThreshold,
-    });
-  });
-}

--- a/ui/src/importFile.ts
+++ b/ui/src/importFile.ts
@@ -135,16 +135,16 @@ function inferSequenceType(values: unknown[]): 'nucleotide' | 'aminoacid' | unde
 }
 
 /**
- * Process raw file bytes to detect columns and update block args.
+ * Process raw file bytes to detect columns and update block data.
  * Called reactively once the file bytes are available via ReactiveFileContent.
  */
 export function processFileBytes(bytes: Uint8Array, extension: string | undefined): void {
   const app = useApp();
 
   // clear state
-  app.model.args.importColumns = undefined;
-  app.model.ui.fileImportError = undefined;
-  app.model.args.detectedXsvType = undefined;
+  app.model.data.importColumns = undefined;
+  app.model.data.fileImportError = undefined;
+  app.model.data.detectedXsvType = undefined;
 
   let rawData: TableData;
 
@@ -154,7 +154,7 @@ export function processFileBytes(bytes: Uint8Array, extension: string | undefine
     const parseResult = parseFastaContent(content);
 
     if (parseResult.error) {
-      app.model.ui.fileImportError = parseResult.error;
+      app.model.data.fileImportError = parseResult.error;
       return;
     }
 
@@ -178,18 +178,18 @@ export function processFileBytes(bytes: Uint8Array, extension: string | undefine
     // so we check the first line of the already-in-memory data buffer.
     if (extension === 'csv' || extension === 'tsv') {
       const firstLine = new TextDecoder().decode(bytes.slice(0, 4096)).split('\n')[0] ?? '';
-      app.model.args.detectedXsvType = firstLine.includes('\t') ? 'tsv' : 'csv';
+      app.model.data.detectedXsvType = firstLine.includes('\t') ? 'tsv' : 'csv';
     }
   }
 
   const header = rawData[0];
   if (!header) {
-    app.model.ui.fileImportError = 'File does not contain any data';
+    app.model.data.fileImportError = 'File does not contain any data';
     return;
   }
 
   if (new Set(header).size !== header.length) {
-    app.model.ui.fileImportError = 'Headers in the input file must be unique';
+    app.model.data.fileImportError = 'Headers in the input file must be unique';
     return;
   }
 
@@ -209,9 +209,9 @@ export function processFileBytes(bytes: Uint8Array, extension: string | undefine
     });
   }
 
-  app.model.args.importColumns = importColumns;
+  app.model.data.importColumns = importColumns;
   if (!importColumns.some((c) => c.sequenceType !== undefined)) {
-    app.model.ui.fileImportError = 'No sequence columns found';
+    app.model.data.fileImportError = 'No sequence columns found';
     return;
   }
 }

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { PlMultiSequenceAlignment } from '@milaboratories/multi-sequence-alignment';
+import strings from '@milaboratories/strings';
+import { getDefaultBlockLabel, type Settings } from '@platforma-open/milaboratories.immune-assay-data.model';
 import type {
   AxisId,
   ImportFileHandle,
@@ -12,13 +14,12 @@ import {
   getRawPlatformaInstance,
   isImportFileHandleUpload,
 } from '@platforma-sdk/model';
-import { getDefaultBlockLabel, type Settings } from '@platforma-open/milaboratories.immune-assay-data.model';
 import {
+  PlAccordionSection,
   PlAgDataTableV2,
   PlAlert,
   PlBlockPage,
   PlBtnGhost,
-  PlAccordionSection,
   PlCheckbox,
   PlDropdown,
   PlDropdownMulti,
@@ -32,7 +33,6 @@ import {
   ReactiveFileContent,
   usePlDataTableSettingsV2,
 } from '@platforma-sdk/ui-vue';
-import strings from '@milaboratories/strings';
 import {
   computed,
   reactive,
@@ -83,11 +83,6 @@ watch(
 );
 
 // Apply modality-aware threshold defaults when the resolved modality flips.
-// `lastAppliedModality` guards the watcher so picking a different dataset of
-// the same modality preserves user-tuned thresholds. The harness flags any
-// `outputs → data` watcher as a hairpin; the multi-client write race is muted
-// here because both clients compute identical writes (same modality → same
-// defaults constant), making the writes idempotent.
 watch(
   () => app.model.outputs.modality,
   (modality) => {

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -258,7 +258,7 @@ const similarityTypeOptions = [
   <PlBlockPage
     v-model:subtitle="app.model.data.customBlockLabel"
     :subtitle-placeholder="defaultLabel"
-    title="Sequence Assay Data"
+    title="Import Assay Data"
   >
     <template #append>
       <PlBtnGhost

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -4,7 +4,6 @@ import type {
   AxisId,
   ImportFileHandle,
   LocalImportFileHandle,
-  PlRef,
   PlSelectionModel,
   PTableKey,
 } from '@platforma-sdk/model';
@@ -13,6 +12,7 @@ import {
   getRawPlatformaInstance,
   isImportFileHandleUpload,
 } from '@platforma-sdk/model';
+import { getDefaultBlockLabel } from '@platforma-open/milaboratories.immune-assay-data.model';
 import {
   PlAgDataTableV2,
   PlAlert,
@@ -53,10 +53,16 @@ import {
 const app = useApp();
 const reactiveFileContent = ReactiveFileContent.useGlobal();
 
-function setDataset(ref: PlRef | undefined) {
-  app.model.args.datasetRef = ref;
-}
-const settingsOpen = ref(app.model.args.datasetRef === undefined);
+const defaultLabel = computed(() =>
+  getDefaultBlockLabel({
+    fileName: app.model.data.fileHandle ? getFileNameFromHandle(app.model.data.fileHandle) : undefined,
+    similarityType: app.model.data.settings.similarityType,
+    identity: app.model.data.settings.identity,
+    coverageThreshold: app.model.data.settings.coverageThreshold,
+  }),
+);
+
+const settingsOpen = ref(app.model.data.datasetRef === undefined);
 const multipleSequenceAlignmentAssayOpen = ref(false);
 const multipleSequenceAlignmentClonotypesOpen = ref(false);
 
@@ -64,7 +70,6 @@ const multipleSequenceAlignmentClonotypesOpen = ref(false);
 watch(
   () => app.model.outputs.isRunning,
   (isRunning, wasRunning) => {
-    // Close settings when block starts running (false -> true transition)
     if (isRunning && !wasRunning) {
       settingsOpen.value = false;
     }
@@ -104,7 +109,6 @@ const assayAxis = computed<AxisId>(() => {
 
 // Open MSA when we click in a row
 const onRowDoubleClicked = reactive((key?: PTableKey) => {
-  // Using keys (that will contain assay ID) we get included clonotypes
   if (key) {
     const assaySpecs = app.model.outputs.assaySequenceSpec;
     if (assaySpecs === undefined) return;
@@ -123,33 +127,37 @@ const assayFileBytes = computed(() => {
   return reactiveFileContent.getContentBytes(handle.handle).value;
 });
 
-// For remote files: detect columns once the prerun has imported the file and bytes arrive.
-// Guarded so it doesn't re-run if a local file already processed bytes synchronously.
+// For remote files: detect columns once the prerun has imported the file and
+// bytes arrive. Guarded so it doesn't re-run if a local file already processed
+// bytes synchronously. The harness flags any `outputs → data` watcher as a
+// hairpin; here the multi-client write race is muted because both clients
+// compute identical `importColumns`/`detectedXsvType` from identical bytes,
+// making racing writes idempotent.
 watch(assayFileBytes, (bytes) => {
-  if (!bytes || !app.model.args.fileHandle) return;
-  if (app.model.args.importColumns !== undefined) return;
-  processFileBytes(bytes, app.model.args.fileExtension);
+  if (!bytes || !app.model.data.fileHandle) return;
+  if (app.model.data.importColumns !== undefined) return;
+  processFileBytes(bytes, app.model.data.fileExtension);
 });
 
 const setFile = async (file: ImportFileHandle | undefined) => {
   // Clear all dependent state so the new file's columns are detected fresh.
-  app.model.args.importColumns = undefined;
-  app.model.args.sequenceColumnHeader = undefined;
-  app.model.args.selectedColumns = [];
-  app.model.args.detectedXsvType = undefined;
-  app.model.ui.fileImportError = undefined;
+  app.model.data.importColumns = undefined;
+  app.model.data.sequenceColumnHeader = undefined;
+  app.model.data.selectedColumns = [];
+  app.model.data.detectedXsvType = undefined;
+  app.model.data.fileImportError = undefined;
 
   if (!file) {
-    app.model.args.fileHandle = undefined;
-    app.model.args.fileExtension = undefined;
+    app.model.data.fileHandle = undefined;
+    app.model.data.fileExtension = undefined;
     return;
   }
 
   const fileName = getFileNameFromHandle(file);
   const extension = fileName.split('.').pop()?.toLowerCase();
-  app.model.args.fileExtension = extension;
+  app.model.data.fileExtension = extension;
   // Setting fileHandle triggers the prerun (needed for remote files and the workflow).
-  app.model.args.fileHandle = file;
+  app.model.data.fileHandle = file;
 
   // For local (upload://) files: process bytes immediately from disk — no prerun round-trip needed.
   // Remote (index://) files fall through to the assayFileBytes watch above.
@@ -163,17 +171,17 @@ const setFile = async (file: ImportFileHandle | undefined) => {
   }
 };
 
-// Watch for when the user selects a sequence column to validate uniqueness
+// Validate selected sequence column for uniqueness when the user picks one.
 watch(
-  () => app.model.args.sequenceColumnHeader,
+  () => app.model.data.sequenceColumnHeader,
   (newHeader) => {
-    if (!newHeader || !app.model.args.fileHandle) {
-      app.model.ui.fileImportError = undefined;
+    if (!newHeader || !app.model.data.fileHandle) {
+      app.model.data.fileImportError = undefined;
       return;
     }
 
     // Skip uniqueness check for FASTA — bytes are FASTA-encoded, not XLSX-parseable
-    const ext = app.model.args.fileExtension;
+    const ext = app.model.data.fileExtension;
     if (ext === 'fasta' || ext === 'fa') return;
 
     const bytes = assayFileBytes.value;
@@ -192,20 +200,20 @@ watch(
       const uniqueSequences = new Set(sequences);
 
       if (sequences.length !== uniqueSequences.size) {
-        app.model.ui.fileImportError = `The selected sequence column '${newHeader}' contains duplicate values.`;
+        app.model.data.fileImportError = `The selected sequence column '${newHeader}' contains duplicate values.`;
       } else {
-        app.model.ui.fileImportError = undefined;
+        app.model.data.fileImportError = undefined;
       }
     } catch (e) {
       console.error('Failed to validate sequence uniqueness:', e);
-      app.model.ui.fileImportError = 'Could not validate sequence uniqueness.';
+      app.model.data.fileImportError = 'Could not validate sequence uniqueness.';
     }
   },
 );
 
 const sequenceColumnOptions = computed(() => {
-  if (!app.model.args.fileHandle) return [];
-  return app.model.args.importColumns
+  if (!app.model.data.fileHandle) return [];
+  return app.model.data.importColumns
     ?.filter((c) => c.sequenceType !== undefined)
     ?.map((c) => ({
       label: c.header,
@@ -214,9 +222,9 @@ const sequenceColumnOptions = computed(() => {
 });
 
 const otherColumnOptions = computed(() => {
-  if (!app.model.args.fileHandle) return [];
-  return app.model.args.importColumns
-    ?.filter((c) => c.header !== app.model.args.sequenceColumnHeader)
+  if (!app.model.data.fileHandle) return [];
+  return app.model.data.importColumns
+    ?.filter((c) => c.header !== app.model.data.sequenceColumnHeader)
     ?.map((c) => ({
       label: c.header,
       value: c.header,
@@ -227,21 +235,12 @@ const similarityTypeOptions = [
   { label: 'BLOSUM', value: 'alignment-score' },
   { label: 'Exact Match', value: 'sequence-identity' },
 ];
-
-// const coverageModeOptions = [
-//   { label: 'Coverage of clone and assay sequences', value: 0 },
-//   { label: 'Coverage of assay sequence', value: 1 },
-//   { label: 'Coverage of clone sequence', value: 2 },
-//   { label: 'Target length ≥ x% of clone length', value: 3 },
-//   { label: 'Query length ≥ x% of assay sequence length', value: 4 },
-//   { label: 'Shorter sequence ≥ x% of longer', value: 5 },
-// ];
 </script>
 
 <template>
   <PlBlockPage
-    v-model:subtitle="app.model.args.customBlockLabel"
-    :subtitle-placeholder="app.model.args.defaultBlockLabel"
+    v-model:subtitle="app.model.data.customBlockLabel"
+    :subtitle-placeholder="defaultLabel"
     title="Immune Assay Data"
   >
     <template #append>
@@ -264,7 +263,7 @@ const similarityTypeOptions = [
       Please choose a different dataset or check your input data.
     </PlAlert>
     <PlAgDataTableV2
-      v-model="app.model.ui.tableState"
+      v-model="app.model.data.tableState"
       v-model:selection="selectionAssay"
       :settings="tableSettings"
       show-columns-panel
@@ -277,11 +276,14 @@ const similarityTypeOptions = [
     <PlSlideModal v-model="settingsOpen" :close-on-outside-click="false">
       <template #title>{{ strings.titles.settings }}</template>
       <PlDropdownRef
-        :model-value="app.model.args.datasetRef" :options="app.model.outputs.datasetOptions"
-        label="Dataset" clearable required @update:model-value="setDataset"
+        v-model="app.model.data.datasetRef"
+        :options="app.model.outputs.datasetOptions"
+        label="Dataset"
+        clearable
+        required
       />
       <PlDropdown
-        v-model="app.model.args.targetRef" :options="app.model.outputs.targetOptions"
+        v-model="app.model.data.targetRef" :options="app.model.outputs.targetOptions"
         label="Clonotype sequence to match" clearable required
       >
         <template #tooltip>
@@ -291,20 +293,20 @@ const similarityTypeOptions = [
         </template>
       </PlDropdown>
       <PlFileInput
-        v-model="app.model.args.fileHandle" label="Assay data to import" placeholder="Assay data table"
-        :extensions="['csv', 'tsv', 'fasta', 'fa', 'xlsx']" :error="app.model.ui.fileImportError" required @update:model-value="setFile"
+        v-model="app.model.data.fileHandle" label="Assay data to import" placeholder="Assay data table"
+        :extensions="['csv', 'tsv', 'fasta', 'fa', 'xlsx']" :error="app.model.data.fileImportError" required @update:model-value="setFile"
       >
         <template #tooltip>
           Upload a comma-separated (.csv), tab-separated (.tsv), or FASTA (.fasta/.fa) file containing assay data. FASTA files will be converted to a table with Header and Sequence columns.
         </template>
       </PlFileInput>
       <!-- @TODO: delete this after bug with not working error message in PlFileInput is fixed -->
-      <span v-if="app.model.ui.fileImportError" style="color: red;">
-        {{ app.model.ui.fileImportError }}
+      <span v-if="app.model.data.fileImportError" style="color: red;">
+        {{ app.model.data.fileImportError }}
       </span>
 
       <PlDropdown
-        v-model="app.model.args.sequenceColumnHeader"
+        v-model="app.model.data.sequenceColumnHeader"
         :options="sequenceColumnOptions"
         label="Assay sequence column"
         placeholder="Sequence column"
@@ -313,7 +315,7 @@ const similarityTypeOptions = [
       />
 
       <PlDropdownMulti
-        v-model="app.model.args.selectedColumns"
+        v-model="app.model.data.selectedColumns"
         :options="otherColumnOptions"
         label="Assay data columns to import"
         placeholder="All columns"
@@ -323,7 +325,7 @@ const similarityTypeOptions = [
 
       <PlSectionSeparator>Matching parameters</PlSectionSeparator>
       <PlDropdown
-        v-model="app.model.args.settings.similarityType" :options="similarityTypeOptions"
+        v-model="app.model.data.settings.similarityType" :options="similarityTypeOptions"
         label="Alignment Score"
       >
         <template #tooltip>
@@ -333,7 +335,7 @@ const similarityTypeOptions = [
       </PlDropdown>
 
       <PlNumberField
-        v-model="app.model.args.settings.identity"
+        v-model="app.model.data.settings.identity"
         label="Score threshold" :min-value="0.1" :step="0.1" :max-value="1.0"
       >
         <template #tooltip>
@@ -342,7 +344,7 @@ const similarityTypeOptions = [
       </PlNumberField>
 
       <PlNumberField
-        v-model="app.model.args.settings.coverageThreshold"
+        v-model="app.model.data.settings.coverageThreshold"
         label="Coverage threshold"
         :min-value="0.1"
         :step="0.1"
@@ -354,7 +356,7 @@ const similarityTypeOptions = [
       </PlNumberField>
 
       <PlAccordionSection :label="strings.titles.advancedSettings">
-        <PlCheckbox v-model="app.model.args.lessSensitive">
+        <PlCheckbox v-model="app.model.data.lessSensitive">
           Fast mode
           <PlTooltip class="info" position="top">
             <template #tooltip>Prioritizes speed over sensitivity. Reduces prefiltering precision, which may miss some weaker matches but significantly speeds up alignment for large datasets.</template>
@@ -363,7 +365,7 @@ const similarityTypeOptions = [
 
         <PlSectionSeparator>Resource allocation</PlSectionSeparator>
         <PlNumberField
-          v-model="app.model.args.mem"
+          v-model="app.model.data.mem"
           label="Memory (GiB)"
           :min-value="1"
           :step="1"
@@ -375,7 +377,7 @@ const similarityTypeOptions = [
         </PlNumberField>
 
         <PlNumberField
-          v-model="app.model.args.cpu"
+          v-model="app.model.data.cpu"
           label="CPU (cores)"
           :min-value="1"
           :step="1"
@@ -394,7 +396,7 @@ const similarityTypeOptions = [
     >
       <template #title>Multiple Sequence Alignment</template>
       <PlMultiSequenceAlignment
-        v-model="app.model.ui.alignmentModel"
+        v-model="app.model.data.alignmentModel"
         :sequence-column-predicate="isAssayColumn"
         :p-frame="app.model.outputs.pf"
         :selection="selectionAssay"
@@ -407,7 +409,7 @@ const similarityTypeOptions = [
     >
       <template #title>Multiple Sequence Alignment</template>
       <PlMultiSequenceAlignment
-        v-model="app.model.ui.alignmentModel"
+        v-model="app.model.data.alignmentModel"
         :sequence-column-predicate="isSequenceColumn"
         :p-frame="app.model.outputs.msaPf"
         :selection="selection"

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -12,7 +12,7 @@ import {
   getRawPlatformaInstance,
   isImportFileHandleUpload,
 } from '@platforma-sdk/model';
-import { getDefaultBlockLabel } from '@platforma-open/milaboratories.immune-assay-data.model';
+import { getDefaultBlockLabel, type Settings } from '@platforma-open/milaboratories.immune-assay-data.model';
 import {
   PlAgDataTableV2,
   PlAlert,
@@ -53,6 +53,12 @@ import {
 const app = useApp();
 const reactiveFileContent = ReactiveFileContent.useGlobal();
 
+// Modality-aware threshold defaults. Applied by the watcher below when the
+// resolved modality changes; switching between two datasets of the same
+// modality preserves user-tuned thresholds.
+const ANTIBODY_DEFAULTS: Settings = { similarityType: 'alignment-score', identity: 0.9, coverageThreshold: 0.95 };
+const PEPTIDE_DEFAULTS: Settings = { similarityType: 'sequence-identity', identity: 1.0, coverageThreshold: 1.0 };
+
 const defaultLabel = computed(() =>
   getDefaultBlockLabel({
     fileName: app.model.data.fileHandle ? getFileNameFromHandle(app.model.data.fileHandle) : undefined,
@@ -76,6 +82,22 @@ watch(
   },
 );
 
+// Apply modality-aware threshold defaults when the resolved modality flips.
+// `lastAppliedModality` guards the watcher so picking a different dataset of
+// the same modality preserves user-tuned thresholds. The harness flags any
+// `outputs → data` watcher as a hairpin; the multi-client write race is muted
+// here because both clients compute identical writes (same modality → same
+// defaults constant), making the writes idempotent.
+watch(
+  () => app.model.outputs.modality,
+  (modality) => {
+    if (!modality) return;
+    if (app.model.data.lastAppliedModality === modality) return;
+    app.model.data.settings = modality === 'peptide' ? PEPTIDE_DEFAULTS : ANTIBODY_DEFAULTS;
+    app.model.data.lastAppliedModality = modality;
+  },
+);
+
 const tableSettings = usePlDataTableSettingsV2({
   model: () => app.model.outputs.table,
 });
@@ -95,13 +117,13 @@ const assayAxis = computed<AxisId>(() => {
   if (app.model.outputs.assaySequenceSpec?.axesSpec[0] === undefined) {
     return {
       type: 'String',
-      name: 'pl7.app/vdj/assay/sequenceId',
+      name: 'pl7.app/assay/sequenceId',
       domain: {},
     };
   } else {
     return {
       type: 'String',
-      name: 'pl7.app/vdj/assay/sequenceId',
+      name: 'pl7.app/assay/sequenceId',
       domain: app.model.outputs.assaySequenceSpec.axesSpec[0].domain,
     };
   }
@@ -241,7 +263,7 @@ const similarityTypeOptions = [
   <PlBlockPage
     v-model:subtitle="app.model.data.customBlockLabel"
     :subtitle-placeholder="defaultLabel"
-    title="Immune Assay Data"
+    title="Sequence Assay Data"
   >
     <template #append>
       <PlBtnGhost
@@ -259,7 +281,7 @@ const similarityTypeOptions = [
     </template>
     <PlAlert v-if="app.model.outputs.emptyClonesInput === true" type="warn" icon>
       <template #title>Empty dataset selection</template>
-      The input dataset you have selected is empty or has no clonotype sequences.
+      The input dataset you have selected is empty or has no sequences.
       Please choose a different dataset or check your input data.
     </PlAlert>
     <PlAgDataTableV2
@@ -284,12 +306,12 @@ const similarityTypeOptions = [
       />
       <PlDropdown
         v-model="app.model.data.targetRef" :options="app.model.outputs.targetOptions"
-        label="Clonotype sequence to match" clearable required
+        label="Sequence column to match" clearable required
       >
         <template #tooltip>
-          Select the sequence column used to match the assay data sequence with. If you select amino acid sequence and
-          the assay data sequence is nucleotide, the assay data sequence will be converted to amino acid sequence
-          automatically.
+          Select the sequence column to align against the assay sequences. If the alphabets differ
+          (e.g., amino acid input vs nucleotide assay), MMseqs2 translates automatically using the
+          appropriate search mode.
         </template>
       </PlDropdown>
       <PlFileInput
@@ -351,7 +373,8 @@ const similarityTypeOptions = [
         :max-value="1.0"
       >
         <template #tooltip>
-          Select min fraction of aligned (covered) residues of clonotypes in the cluster.
+          Minimum fraction of residues that must align between the input sequence and the assay
+          sequence to count as a match.
         </template>
       </PlNumberField>
 

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -1,27 +1,27 @@
-import type { PColumnPredicate, PColumnSpec } from '@platforma-sdk/model';
-import { Annotation, Domain, PAxisName, PColumnName, readAnnotationJson, readDomain } from '@platforma-sdk/model';
+import type { PColumnPredicate } from '@platforma-sdk/model';
+import { Annotation, Domain, PAxisName, readAnnotationJson, readDomain } from '@platforma-sdk/model';
 
 export const isAssayColumn: PColumnPredicate = ({ spec }) =>
-  spec.name === PColumnName.VDJ.Sequence
-  && spec.axesSpec[0].name === PAxisName.VDJ.Assay.SequenceId;
+  spec.name === 'pl7.app/sequence'
+  && spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId';
 
 export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
-  const isBulkSequence = (spec: PColumnSpec) =>
-    spec.name !== 'pl7.app/vdj/sequenceLength'
-    && spec.name !== 'pl7.app/vdj/sequence/annotation'
-    && spec.axesSpec[0].name !== PAxisName.VDJ.Assay.SequenceId
-    && readDomain(spec, Domain.Alphabet) === 'aminoacid';
-
-  const isSingleCellSequence = (spec: PColumnSpec) =>
-    spec.name !== 'pl7.app/vdj/sequenceLength'
-    && spec.name !== 'pl7.app/vdj/sequence/annotation'
-    && readDomain(spec, Domain.VDJ.ScClonotypeChain.Index) === 'primary'
-    && readDomain(spec, Domain.Alphabet) === 'aminoacid'
-    // && column.axesSpec.length >= 1
-    && spec.axesSpec[0].name === PAxisName.VDJ.ScClonotypeKey;
-
-  return (isBulkSequence(spec) || isSingleCellSequence(spec))
-    && {
-      default: readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature) ?? false,
-    };
+  if (spec.name === 'pl7.app/vdj/sequenceLength' || spec.name === 'pl7.app/vdj/sequence/annotation') return false;
+  if (spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId') return false;
+  if (readDomain(spec, Domain.Alphabet) !== 'aminoacid') return false;
+  if (
+    spec.axesSpec[0]?.name === PAxisName.VDJ.ScClonotypeKey
+    && readDomain(spec, Domain.VDJ.ScClonotypeChain.Index) !== 'primary'
+  ) {
+    return false;
+  }
+  // `readAnnotationJson` enforces a runtime schema lookup that fails for keys not
+  // registered in the SDK's AnnotationJson map; the error is caught upstream and
+  // returns undefined. So we read the neutral form by direct annotation access
+  // until the SDK ships a typed constant for it.
+  // TODO: replace direct access with `readAnnotationJson(spec, Annotation.IsAssemblingFeature)` after SDK rename.
+  const isAssemblingFeature
+    = readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature)
+      ?? spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true';
+  return { default: isAssemblingFeature };
 };

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -13,11 +13,11 @@ export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
   ) return false;
   if (spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId') return false;
   if (readDomain(spec, Domain.Alphabet) !== 'aminoacid') return false;
-  if (
-    spec.axesSpec[0]?.name === PAxisName.VDJ.ScClonotypeKey
-    && readDomain(spec, Domain.VDJ.ScClonotypeChain.Index) !== 'primary'
-  ) {
-    return false;
+  if (spec.axesSpec[0]?.name === PAxisName.VDJ.ScClonotypeKey) {
+    const chainIndex = readDomain(spec, Domain.VDJ.ScClonotypeChain.Index);
+    // Reject non-primary chains (e.g. light), but keep chain-less constructs
+    // like scFv where the domain field is absent entirely.
+    if (chainIndex !== undefined && chainIndex !== 'primary') return false;
   }
   // TODO: replace direct access with `readAnnotationJson(spec, Annotation.IsAssemblingFeature)` after SDK rename.
   const isAssemblingFeature

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -19,10 +19,6 @@ export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
   ) {
     return false;
   }
-  // `readAnnotationJson` enforces a runtime schema lookup that fails for keys not
-  // registered in the SDK's AnnotationJson map; the error is caught upstream and
-  // returns undefined. So we read the neutral form by direct annotation access
-  // until the SDK ships a typed constant for it.
   // TODO: replace direct access with `readAnnotationJson(spec, Annotation.IsAssemblingFeature)` after SDK rename.
   const isAssemblingFeature
     = readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature)

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -6,7 +6,11 @@ export const isAssayColumn: PColumnPredicate = ({ spec }) =>
   && spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId';
 
 export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
-  if (spec.name === 'pl7.app/vdj/sequenceLength' || spec.name === 'pl7.app/vdj/sequence/annotation') return false;
+  if (
+    spec.name === 'pl7.app/vdj/sequenceLength'
+    || spec.name === 'pl7.app/sequenceLength'
+    || spec.name === 'pl7.app/vdj/sequence/annotation'
+  ) return false;
   if (spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId') return false;
   if (readDomain(spec, Domain.Alphabet) !== 'aminoacid') return false;
   if (

--- a/workflow/src/analysis.tpl.tengo
+++ b/workflow/src/analysis.tpl.tengo
@@ -278,7 +278,9 @@ self.body(func(args) {
 		similarityType: similarityType,
 		clonesFasta: chunk1Fasta,
 		assayFasta: assayFasta,
-		lessSensitive: lessSensitive
+		lessSensitive: lessSensitive,
+		isPeptide: args.isPeptide,
+		minPeptideLength: args.minPeptideLength
 	}, {
 		metaInputs: {
 			mem: mem,
@@ -293,7 +295,9 @@ self.body(func(args) {
 		similarityType: similarityType,
 		clonesFasta: chunk2Fasta,
 		assayFasta: assayFasta,
-		lessSensitive: lessSensitive
+		lessSensitive: lessSensitive,
+		isPeptide: args.isPeptide,
+		minPeptideLength: args.minPeptideLength
 	}, {
 		metaInputs: {
 			mem: mem,

--- a/workflow/src/build-outputs.tpl.tengo
+++ b/workflow/src/build-outputs.tpl.tengo
@@ -15,6 +15,15 @@ assayColumnName := func(header) {
 }
 
 self.body(func(inputs) {
+	// Display labels reflect what the upstream actually carries — clones for
+	// VDJ, peptides for peptide-extraction. Column/axis `name`s stay neutral
+	// (`pl7.app/assay/*`); labels diverge because the upstream-side semantics
+	// differ: queryCount counts clones vs peptides, and the linker column's
+	// `target` axis is `clonotypeKey` vs `variantKey` — different identities.
+	isPeptide := inputs.datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	matchedCountLabel := isPeptide ? "Matched Peptides" : "Matched Clones"
+	linkerLabel := isPeptide ? "Peptide to assay link" : "Clone to assay link"
+
 	//////// Building outputs & exports ////////
 	assayColumns := [
 		{
@@ -27,14 +36,14 @@ self.body(func(inputs) {
 					"pl7.app/table/fontFamily": "monospace"
 				}
 			}
-		},	
+		},
 		{
 			column: "queryCount",
 			spec: {
 				name: "pl7.app/assay/queryCount",
 				valueType: "Int",
 				annotations: {
-					"pl7.app/label": "Matched Clones",
+					"pl7.app/label": matchedCountLabel,
 					"pl7.app/table/orderPriority": "9000"
 				}
 			}
@@ -214,7 +223,7 @@ self.body(func(inputs) {
 					valueType: "Int",
 					annotations: {
 						"pl7.app/isLinkerColumn": "true",
-						"pl7.app/label": "Clone to assay link",
+						"pl7.app/label": linkerLabel,
 						"pl7.app/table/visibility": "hidden"
 					}
 				}

--- a/workflow/src/build-outputs.tpl.tengo
+++ b/workflow/src/build-outputs.tpl.tengo
@@ -11,7 +11,7 @@ self.awaitState("assaySequenceType", "ResourceReady")
 self.awaitState("sequenceColumnInfo", "ResourceReady")
 
 assayColumnName := func(header) {
-	return "pl7.app/vdj/assay-data/" + strings.substituteSpecialCharacters(header)
+	return "pl7.app/assay-data/" + strings.substituteSpecialCharacters(header)
 }
 
 self.body(func(inputs) {
@@ -31,19 +31,19 @@ self.body(func(inputs) {
 		{
 			column: "queryCount",
 			spec: {
-				name: "pl7.app/vdj/assay/queryCount",
+				name: "pl7.app/assay/queryCount",
 				valueType: "Int",
 				annotations: {
 					"pl7.app/label": "Matched Clones",
 					"pl7.app/table/orderPriority": "9000"
 				}
 			}
-		},	
+		},
 		{
 			column: inputs.sequenceColumnInfo.header,
 			id: strings.substituteSpecialCharacters(inputs.sequenceColumnInfo.header),
 			spec: {
-				name: "pl7.app/vdj/sequence",
+				name: "pl7.app/sequence",
 				valueType: "String",
 				domain: {
 					"pl7.app/alphabet": inputs.assaySequenceType
@@ -79,7 +79,7 @@ self.body(func(inputs) {
 		axes: [{
 			column: "seqId",
 			spec: {
-				name: "pl7.app/vdj/assay/sequenceId",
+				name: "pl7.app/assay/sequenceId",
 				type: "String",
 				domain: {
 					"pl7.app/blockId": inputs.blockId
@@ -100,7 +100,7 @@ self.body(func(inputs) {
 	{
 		column: "seqIdLabel",
 		spec: {
-			name: "pl7.app/vdj/assay/sequenceIdLabel",
+			name: "pl7.app/assay/sequenceIdLabel",
 			valueType: "String",
 			annotations: {
 				"pl7.app/label": "Assay Sequence Id",
@@ -195,7 +195,7 @@ self.body(func(inputs) {
 				{
 					column: "query",
 					spec: {
-						name: "pl7.app/vdj/assay/sequenceId",
+						name: "pl7.app/assay/sequenceId",
 						type: "String",
 						domain: {
 							"pl7.app/blockId": inputs.blockId
@@ -210,7 +210,7 @@ self.body(func(inputs) {
 			columns: [{
 				column: "link",
 				spec: {
-					name: "pl7.app/vdj/link",
+					name: "pl7.app/link",
 					valueType: "Int",
 					annotations: {
 						"pl7.app/isLinkerColumn": "true",

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -23,8 +23,15 @@ checkContentEmptySw := assets.importSoftware("@platforma-open/milaboratories.imm
 
 wf.prepare(func(args){
 	bundleBuilder := wf.createPBundleBuilder()
-	bundleBuilder.addAnchor("main", args.datasetRef) 
+	bundleBuilder.addAnchor("main", args.datasetRef)
 	bundleBuilder.addSingle(args.targetRef)
+	// Peptide-only: per-peptide length column drives the short-peptide k-mer
+	// override in run-alignment. Empty bundle slot on VDJ inputs.
+	bundleBuilder.addMulti({
+		axes: [{ anchor: "main", idx: 1 }],
+		name: "pl7.app/sequenceLength",
+		domain: { "pl7.app/feature": "peptide" }
+	}, "peptideSequenceLength")
 	return {
 		columns: bundleBuilder.build()
 	}
@@ -48,6 +55,45 @@ wf.body(func(args) {
 	importFile := file.importFile(args.fileHandle)
 	datasetSpec := args.columns.getSpec(args.datasetRef)
 	targetSpec := args.columns.getSpec(args.targetRef)
+
+	// Detect peptide modality and compute min peptide length when applicable.
+	// Drives the short-peptide k-mer override in run-alignment (k=5 + relaxed
+	// mmseqs2 prefilter for inputs below the auto-tune floor of ~6).
+	isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	minPeptideLength := undefined
+	if isPeptide {
+		peptideLenCols := args.columns.getColumns("peptideSequenceLength")
+		if len(peptideLenCols) == 0 {
+			ll.panic("Peptide input is missing required pl7.app/sequenceLength column")
+		}
+		// Peptide-extraction emits both aa and nt length columns under the same
+		// name + feature domain; pick the one matching the target's alphabet so
+		// the k-mer threshold reflects the actual search-side sequence length.
+		targetAlphabet := targetSpec.domain["pl7.app/alphabet"]
+		matchedLenCol := undefined
+		for col in peptideLenCols {
+			if col.spec.domain["pl7.app/alphabet"] == targetAlphabet {
+				matchedLenCol = col
+				break
+			}
+		}
+		if is_undefined(matchedLenCol) {
+			ll.panic("No peptide length column matches target alphabet: ", targetAlphabet)
+		}
+		// pt's `min` is a window function — bare `select(min())` doesn't fold the
+		// whole frame. Use `groupBy` with a constant key to aggregate across all
+		// rows. Filter `len > 0` because peptide-extraction emits 0-length rows
+		// for some variants (see peptide-extraction/compute-qc-sample.tpl.tengo:60).
+		minLenWf := pt.workflow()
+		minLenWf.frame(pt.p.column("len", { spec: matchedLenCol.spec, data: matchedLenCol.data })).
+			filter(pt.col("len").gt(pt.lit(0))).
+			withColumns(pt.lit(1).alias("_g")).
+			groupBy("_g").
+			agg(pt.col("len").min().alias("min_len")).
+			saveContent("min_len.ndjson")
+		minLenResult := minLenWf.run()
+		minPeptideLength = minLenResult.getFileContent("min_len.ndjson")
+	}
 	
 	// aminoacid or nucleotide
 	sequenceColumnInfo := undefined
@@ -141,7 +187,9 @@ wf.body(func(args) {
 		similarityType: args.settings.similarityType,
 		lessSensitive: args.lessSensitive,
 		importColumns: args.importColumns,
-		selectedColumns: args.selectedColumns
+		selectedColumns: args.selectedColumns,
+		isPeptide: isPeptide,
+		minPeptideLength: minPeptideLength
 	}, {
 		metaInputs: {
 			mem: args.mem,

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -80,16 +80,9 @@ wf.body(func(args) {
 		if is_undefined(matchedLenCol) {
 			ll.panic("No peptide length column matches target alphabet: ", targetAlphabet)
 		}
-		// pt's `min` is a window function — bare `select(min())` doesn't fold the
-		// whole frame. Use `groupBy` with a constant key to aggregate across all
-		// rows. Filter `len > 0` because peptide-extraction emits 0-length rows
-		// for some variants (see peptide-extraction/compute-qc-sample.tpl.tengo:60).
 		minLenWf := pt.workflow()
 		minLenWf.frame(pt.p.column("len", { spec: matchedLenCol.spec, data: matchedLenCol.data })).
-			filter(pt.col("len").gt(pt.lit(0))).
-			withColumns(pt.lit(1).alias("_g")).
-			groupBy("_g").
-			agg(pt.col("len").min().alias("min_len")).
+			select(pt.col("len").min().alias("min_len")).
 			saveContent("min_len.ndjson")
 		minLenResult := minLenWf.run()
 		minPeptideLength = minLenResult.getFileContent("min_len.ndjson")

--- a/workflow/src/run-alignment.tpl.tengo
+++ b/workflow/src/run-alignment.tpl.tengo
@@ -52,8 +52,58 @@ self.body(func(args) {
 		mmseqs = mmseqs.
 			arg("--comp-bias-corr").arg("0").
 			arg("--mask").arg("0").
-			arg("--exact-kmer-matching").arg("1").
-			arg("-k").arg("7")
+			arg("--exact-kmer-matching").arg("1")
+		// -k determined below: peptide-min-length override may win over Fast mode's k=7.
+	}
+
+	// MMseqs2's `-k 0` auto-tune floors at ~6 and Fast mode's `-k 7` has the
+	// same problem: sub-k-aa peptides produce zero k-mers and silently miss
+	// every match (no error, just empty results). Force `-k 5` whenever the
+	// shortest input peptide is below 10 aa, taking precedence over Fast mode.
+	//
+	// The spec called only for `-k 5`, but empirically that's not enough —
+	// MMseqs2 has several other defaults that quietly filter short alignments,
+	// so the additional flags below mirror clonotype-clustering's
+	// "highPrecision" mode (clonotype-clustering/workflow/src/clustering.tpl.tengo)
+	// which solves the same problem for short CDRs.
+	isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
+	shortPeptide := false
+	if isPeptide && !is_undefined(args.minPeptideLength) {
+		parsed := args.minPeptideLength.getDataAsJson()
+		ml := int(parsed.min_len)
+		if ml < 10 {
+			shortPeptide = true
+		}
+	}
+	kValue := undefined
+	if shortPeptide {
+		kValue = "5"
+		mmseqs = mmseqs.
+			// Default `--spaced-kmer-mode 1` (spaced k-mers) requires informative
+			// positions spread over a span longer than k, so with k=5 and a
+			// 7-aa peptide no valid k-mer can be formed. `0` switches to
+			// consecutive k-mers so every length-k substring is a candidate hit.
+			arg("--spaced-kmer-mode").arg("0").
+			// Default `--min-ungapped-score 15` filters very short alignments
+			// after the k-mer prefilter. For sub-7-aa hits BLOSUM62 ungapped
+			// scores can fall below 15 even for exact matches. `0` disables
+			// the floor.
+			arg("--min-ungapped-score").arg("0").
+			// Default `-s` is around 5.7. Higher sensitivity widens the
+			// prefilter, which we need at k=5 to ensure short-peptide hits
+			// propagate from prefilter to alignment.
+			arg("-s").arg("7.5").
+			// Default `-e 1e-3` rejects alignments with high e-value. e-value
+			// scales with database size and inversely with bit score, so even
+			// an exact 7-aa hit can exceed the threshold against a large
+			// peptide DB. `inf` removes the filter; `--min-seq-id 1.0` + full
+			// coverage already constrain the match to true exact identity.
+			arg("-e").arg("inf")
+	} else if lessSensitive {
+		kValue = "7"
+	}
+	if !is_undefined(kValue) {
+		mmseqs = mmseqs.arg("-k").arg(kValue)
 	}
 
 	mmseqs = mmseqs.

--- a/workflow/src/run-alignment.tpl.tengo
+++ b/workflow/src/run-alignment.tpl.tengo
@@ -53,19 +53,10 @@ self.body(func(args) {
 			arg("--comp-bias-corr").arg("0").
 			arg("--mask").arg("0").
 			arg("--exact-kmer-matching").arg("1")
-		// -k determined below: peptide-min-length override may win over Fast mode's k=7.
 	}
 
-	// MMseqs2's `-k 0` auto-tune floors at ~6 and Fast mode's `-k 7` has the
-	// same problem: sub-k-aa peptides produce zero k-mers and silently miss
-	// every match (no error, just empty results). Force `-k 5` whenever the
-	// shortest input peptide is below 10 aa, taking precedence over Fast mode.
-	//
-	// The spec called only for `-k 5`, but empirically that's not enough —
-	// MMseqs2 has several other defaults that quietly filter short alignments,
-	// so the additional flags below mirror clonotype-clustering's
-	// "highPrecision" mode (clonotype-clustering/workflow/src/clustering.tpl.tengo)
-	// which solves the same problem for short CDRs.
+	// MMseqs2's `-k 0` auto-tune floors at ~6, force `-k 5` whenever the
+	// shortest input peptide is below 10 aa,
 	isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
 	shortPeptide := false
 	if isPeptide && !is_undefined(args.minPeptideLength) {
@@ -77,27 +68,12 @@ self.body(func(args) {
 	}
 	kValue := undefined
 	if shortPeptide {
+		// Set default parameters adapted for short sequences
 		kValue = "5"
 		mmseqs = mmseqs.
-			// Default `--spaced-kmer-mode 1` (spaced k-mers) requires informative
-			// positions spread over a span longer than k, so with k=5 and a
-			// 7-aa peptide no valid k-mer can be formed. `0` switches to
-			// consecutive k-mers so every length-k substring is a candidate hit.
 			arg("--spaced-kmer-mode").arg("0").
-			// Default `--min-ungapped-score 15` filters very short alignments
-			// after the k-mer prefilter. For sub-7-aa hits BLOSUM62 ungapped
-			// scores can fall below 15 even for exact matches. `0` disables
-			// the floor.
 			arg("--min-ungapped-score").arg("0").
-			// Default `-s` is around 5.7. Higher sensitivity widens the
-			// prefilter, which we need at k=5 to ensure short-peptide hits
-			// propagate from prefilter to alignment.
 			arg("-s").arg("7.5").
-			// Default `-e 1e-3` rejects alignments with high e-value. e-value
-			// scales with database size and inversely with bit score, so even
-			// an exact 7-aa hit can exceed the threshold against a large
-			// peptide DB. `inf` removes the filter; `--min-seq-id 1.0` + full
-			// coverage already constrain the match to true exact identity.
 			arg("-e").arg("inf")
 	} else if lessSensitive {
 		kValue = "7"


### PR DESCRIPTION
- Unified BlockData (UI-shaped); args lambda projects workflow shape and validates by throw (replaces argsValid)
- prerunArgs projects fileHandle for the file-import prerun
- defaultBlockLabel no longer stored: args lambda and subtitle derive it inline from data.fileHandle + data.settings via the pure getFileNameFromHandle. The syncDefaultBlockLabel hairpin is removed
- Persisted V1 state preserved via DataModelBuilder.upgradeLegacy
- UI bindings move to app.model.data; defineApp -> defineAppV3
- Bump SDK to 1.77.4 (model, ui-vue, workflow-tengo, test, graph-maker)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the Immune Assay Data block from `BlockModel` (V1) to `BlockModelV3`, collapsing the separate `args` and `uiState` into a single unified `BlockData` shape persisted and bound directly through `app.model.data`. Legacy persisted state is preserved via `DataModelBuilder.upgradeLegacy`.

- **Model**: `BlockModelV3.create(blockDataModel)` with validation-by-throw in `.args()`, a `prerunArgs` projection for the file-import prerun, and inline `deriveDefaultLabel` replacing the old `syncDefaultBlockLabel` hairpin watcher. The version tag `'V20260519'` marks the new schema.
- **UI**: All template bindings move from `app.model.args`/`app.model.uiState` to `app.model.data`; `defineApp` → `defineAppV3`; the `outputs → data` watcher for file-bytes processing is preserved with an idempotency comment.
- **Dependencies**: SDK bumped to 1.77.4 across model, ui-vue, workflow-tengo, and related packages.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The migration is structurally sound and legacy state is correctly preserved; two small polish issues in validation ordering and the PlFileInput binding pattern are worth fixing before merge but neither causes data loss or a broken workflow.

The args lambda checks importColumns === undefined before fileImportError, so a file that fails to parse for a user-visible reason (duplicate headers, empty file) will report 'Assay file has not been parsed yet' in the block status rather than the actual error text. Separately, the PlFileInput carries both v-model and @update:model-value='setFile', writing fileHandle a tick before setFile clears the dependent fields. Vue's async scheduler prevents a user-visible bug today, but the double write is fragile. Both issues are confined to the settings/input flow and do not affect workflow execution or persisted data.

model/src/index.ts (validation guard order) and ui/src/pages/MainPage.vue (PlFileInput binding)
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Core migration to BlockModelV3: DataModelBuilder with upgradeLegacy, args-by-throw validation, prerunArgs for fileHandle projection. Minor: fileImportError check fires after importColumns check, surfacing a misleading error message when file parsing fails. |
| model/src/types.ts | New file extracting BlockData, BlockArgs, BlockPrerunArgs, and the two legacy snapshot types used by upgradeLegacy. Types are clean and consistent with the migration. |
| ui/src/pages/MainPage.vue | All bindings moved from args/uiState to app.model.data. The assayFileBytes outputs→data watcher is preserved with an idempotency comment. PlFileInput uses both v-model and @update:model-value, writing fileHandle before setFile clears dependent state. |
| ui/src/app.ts | Minimal change: defineApp → defineAppV3, model export renamed to platforma. Clean. |
| ui/src/importFile.ts | processFileBytes now writes directly to app.model.data instead of separate args/uiState targets. Logic is otherwise unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects file] --> B[setFile called]
    B --> C[Clear importColumns / sequenceColumnHeader / etc.]
    C --> D[Set fileExtension + fileHandle]
    D --> E{Local file?}
    E -- yes --> F[getLocalFileContent]
    F --> G[processFileBytes]
    G --> H[Set importColumns / fileImportError]
    E -- no / remote --> I[Prerun triggered by fileHandle change]
    I --> J[outputs.assayFileHandle available]
    J --> K[assayFileBytes computed non-null]
    K --> L{importColumns already set?}
    L -- yes --> M[Skip — local file already processed]
    L -- no --> G
    H --> N[User picks sequenceColumnHeader]
    N --> O{assayFileBytes available?}
    O -- yes --> P[Uniqueness check via XLSX re-parse]
    O -- no --> Q[Check silently skipped]
    H --> R[args lambda called]
    R --> S{fileImportError set AND importColumns undefined?}
    S -- yes --> T[Throws 'not parsed yet' instead of actual error]
    S -- no --> U[Normal validation proceeds]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
model/src/index.ts:104-107
When file parsing fails and sets `fileImportError` while leaving `importColumns` as `undefined` (e.g., "File does not contain any data" or "Headers in the input file must be unique"), the `importColumns` guard fires first and the block reports "Assay file has not been parsed yet" instead of the actual parse error message. Moving the `fileImportError` check above the `importColumns` check ensures the user-visible block-status message matches what went wrong.

```suggestion
    if (data.fileHandle === undefined) throw new Error('Assay file is required');
    if (data.fileImportError !== undefined) throw new Error(data.fileImportError);
    if (data.importColumns === undefined) throw new Error('Assay file has not been parsed yet');
    if (data.sequenceColumnHeader === undefined) throw new Error('Assay sequence column is required');
```

### Issue 2 of 2
ui/src/pages/MainPage.vue:295-297
`v-model` expands to `:modelValue="..." @update:modelValue="fileHandle = $event"`, so combining it with a second `@update:model-value="setFile"` handler means `fileHandle` is written to the new value *before* `setFile` clears `importColumns`, `sequenceColumnHeader`, and the other dependent fields. Using a read-only `:model-value` binding keeps the displayed file in sync while letting `setFile` own all the writes.

```suggestion
      <PlFileInput
        :model-value="app.model.data.fileHandle" label="Assay data to import" placeholder="Assay data table"
        :extensions="['csv', 'tsv', 'fasta', 'fa', 'xlsx']" :error="app.model.data.fileImportError" required @update:model-value="setFile"
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Migrate to BlockModelV3"](https://github.com/platforma-open/immune-assay-data/commit/fab9f9c31d001f9a9ddacb9e59a919a1b516457e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32828948)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->