### PR TITLE
MILAB-6255: Accept peptide datasets; rename to Sequence Assay Data

### DIFF
--- a/.changeset/peptide-universalize.md
+++ b/.changeset/peptide-universalize.md
@@ -1,0 +1,18 @@
+---
+"@platforma-open/milaboratories.immune-assay-data.workflow": minor
+"@platforma-open/milaboratories.immune-assay-data.model": minor
+"@platforma-open/milaboratories.immune-assay-data.ui": minor
+"@platforma-open/milaboratories.immune-assay-data": minor
+---
+
+Accept peptide datasets alongside VDJ clonotypes; rename to "Sequence Assay Data".
+
+The block now discovers peptide-extraction anchors (`pl7.app/variantKey`) in addition to bulk and single-cell VDJ; target-column selection branches on the dataset axis. A new retentive `modality` model output exposes `'peptide' | 'antibody_tcr'` derived from the dataset spec. The UI applies modality-aware threshold defaults — antibody/TCR keeps the previous BLOSUM defaults (`alignment-score / 0.9 / 0.95`); peptide flips to exact-match (`sequence-identity / 1.0 / 1.0`). Switching between datasets of the same modality preserves user-tuned thresholds; legacy projects' tuning is preserved via `lastAppliedModality: 'antibody_tcr'` in `upgradeLegacy`.
+
+Block-emitted column and axis names are now modality-neutral — `pl7.app/assay-data/*`, `pl7.app/assay/queryCount`, `pl7.app/sequence` (assay sequence), `pl7.app/assay/sequenceId`, `pl7.app/assay/sequenceIdLabel`, `pl7.app/link`. The `assay/` and `assay-data/` sub-namespaces remain; modality is recovered by consumers from the natural input axis on each column. Downstream blocks consuming via axis-anchored queries are unaffected.
+
+Short-peptide k-mer override: when the shortest input peptide is below 10 aa, the MMseqs2 prefilter is reconfigured for short sequences (`-k 5 --spaced-kmer-mode 0 --min-ungapped-score 0 -s 7.5 -e inf`). The spec called only for `-k 5`; the additional flags were required empirically to make sub-7-aa exact matches actually return hits — defaults silently filter them. Mirrors clonotype-clustering's `highPrecision` short-CDR mode. The override takes precedence over Fast mode's hardcoded `-k 7`.
+
+Block catalog name changes from "Immune Assay Data" to "Sequence Assay Data"; `block.meta.tags` gains `peptide`; description and long-form docs rewritten to be modality-neutral. The block ID, npm package name, and directory remain `immune-assay-data` — technical identifiers unchanged.
+
+UI: `isAssayColumn` and `isSequenceColumn` predicates updated for neutral names and the peptide variant axis; `isSequenceColumn` now reads both VDJ-namespaced and neutral `isAssemblingFeature` annotations so peptide aa columns are default-selected in the MSA dialog. Empty-state alert, target-dropdown label/tooltip, and coverage-threshold tooltip rewritten to drop VDJ flavor.

--- a/block/package.json
+++ b/block/package.json
@@ -23,18 +23,19 @@
       "ui": "@platforma-open/milaboratories.immune-assay-data.ui/dist"
     },
     "meta": {
-      "title": "Immune Assay Data",
+      "title": "Sequence Assay Data",
       "logo": "file:../logos/block-logo.png",
       "url": "https://github.com/platforma-open/immune-assay-data",
       "docs": "https://docs.platforma.bio/guides/antibody-discovery/functinal-assay-data/",
       "support": "mailto:support@milaboratories.com",
-      "description": "Imports immune assay data and aligns clonotypes with assay sequences using MMseqs2 to assign functional annotations.",
+      "description": "Imports assay data and uses MMseqs2 to align its sequences to clonotypes or peptides and assign functional annotations.",
       "longDescription": "file:../docs/description.md",
       "changelog": "file:../CHANGELOG.md",
       "tags": [
         "airr",
         "downstream",
-        "assay"
+        "assay",
+        "peptide"
       ],
       "organization": {
         "name": "MiLaboratories Inc",

--- a/docs/description.md
+++ b/docs/description.md
@@ -1,8 +1,8 @@
 # Overview
 
-Imports immune assay data containing nucleotide or amino acid sequences with associated metadata and aligns clonotypes from V(D)J analysis with the assay database to assign functional annotations. The block uses MMseqs2's easy-search functionality to perform sensitive sequence alignment between clonotype sequences and assay database sequences, assigning metadata (such as antigen specificity, binding affinity, or functional properties) to matching clonotypes.
+Imports assay data containing nucleotide or amino acid sequences with associated metadata and aligns it to clonotypes or peptides to assign functional annotations. The block uses MMseqs2's easy-search functionality to perform sensitive sequence alignment between input sequences and assay database sequences, assigning metadata (such as antigen specificity, binding affinity, or functional properties) to matching sequences.
 
-The enriched clonotype data with assay annotations can be used in downstream analysis blocks such as Clonotype Browser to filter, explore, and analyze clonotypes based on their functional properties.
+The enriched data with assay annotations can be used in downstream analysis blocks such as Sequence Browser to filter, explore, and analyze sequences based on their functional properties.
 
 MMseqs2 is developed by the Söding lab and Steinegger group. For more information, please see: [https://github.com/soedinglab/MMseqs2](https://github.com/soedinglab/MMseqs2) and cite the following publication if used in your research:
 

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -22,6 +22,7 @@ import type {
   BlockPrerunArgs,
   LegacyBlockArgs,
   LegacyBlockUiState,
+  Modality,
   Settings,
 } from './types';
 
@@ -52,6 +53,9 @@ const blockDataModel = new DataModelBuilder()
     fileImportError: uiState?.fileImportError,
     tableState: uiState?.tableState ?? createPlDataTableStateV2(),
     alignmentModel: uiState?.alignmentModel ?? {},
+    // Pre-peptide-support projects are always antibody/TCR; seeding this prevents
+    // the modality-reset watcher from clobbering user-tuned thresholds on reopen.
+    lastAppliedModality: 'antibody_tcr',
   }))
   .init(() => ({
     customBlockLabel: '',
@@ -70,6 +74,7 @@ const blockDataModel = new DataModelBuilder()
     fileImportError: undefined,
     tableState: createPlDataTableStateV2(),
     alignmentModel: {},
+    lastAppliedModality: undefined,
   }));
 
 function deriveDefaultLabel(data: BlockData): string {
@@ -100,7 +105,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .args<BlockArgs>((data) => {
     if (data.datasetRef === undefined) throw new Error('Dataset is required');
-    if (data.targetRef === undefined) throw new Error('Target clonotype sequence is required');
+    if (data.targetRef === undefined) throw new Error('Sequence column to match is required');
     if (data.fileHandle === undefined) throw new Error('Assay file is required');
     if (data.importColumns === undefined) throw new Error('Assay file has not been parsed yet');
     if (data.sequenceColumnHeader === undefined) throw new Error('Assay sequence column is required');
@@ -140,22 +145,39 @@ export const platforma = BlockModelV3.create(blockDataModel)
         { name: 'pl7.app/vdj/scClonotypeKey' },
       ],
       annotations: { 'pl7.app/isAnchor': 'true' },
+    }, {
+      axes: [
+        { name: 'pl7.app/sampleId' },
+        { name: 'pl7.app/variantKey' },
+      ],
+      annotations: { 'pl7.app/isAnchor': 'true' },
     }], {}),
   )
+
+  .output('modality', (ctx): Modality | undefined => {
+    if (ctx.data.datasetRef === undefined) return undefined;
+    const spec = ctx.resultPool.getPColumnSpecByRef(ctx.data.datasetRef);
+    if (spec === undefined) return undefined;
+    return spec.axesSpec[1]?.name === 'pl7.app/variantKey' ? 'peptide' : 'antibody_tcr';
+  }, { retentive: true })
 
   .output('targetOptions', (ctx) => {
     const ref = ctx.data.datasetRef;
     if (ref === undefined) return undefined;
 
-    const isSingleCell = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1].name === 'pl7.app/vdj/scClonotypeKey';
+    const datasetAxis = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name;
     const sequenceMatchers = [];
-    if (isSingleCell) {
+    if (datasetAxis === 'pl7.app/variantKey') {
+      sequenceMatchers.push({
+        axes: [{ anchor: 'main', idx: 1 }],
+        name: 'pl7.app/sequence',
+        domain: { 'pl7.app/feature': 'peptide' },
+      });
+    } else if (datasetAxis === 'pl7.app/vdj/scClonotypeKey') {
       sequenceMatchers.push({
         axes: [{ anchor: 'main', idx: 1 }],
         name: 'pl7.app/vdj/sequence',
-        domain: {
-          'pl7.app/vdj/scClonotypeChain/index': 'primary',
-        },
+        domain: { 'pl7.app/vdj/scClonotypeChain/index': 'primary' },
       });
     } else {
       sequenceMatchers.push({
@@ -213,8 +235,8 @@ export const platforma = BlockModelV3.create(blockDataModel)
     }
     const cols = ctx.outputs?.resolve('table')?.getPColumns();
     if (cols === undefined) return undefined;
-    return cols.find((c) => c.spec.name === 'pl7.app/vdj/sequence'
-      && c.spec.axesSpec[0].name === 'pl7.app/vdj/assay/sequenceId')?.spec;
+    return cols.find((c) => c.spec.name === 'pl7.app/sequence'
+      && c.spec.axesSpec[0].name === 'pl7.app/assay/sequenceId')?.spec;
   })
 
   .output('msaPf', (ctx) => {
@@ -239,7 +261,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
 
   .output('isRunning', (ctx) => ctx.outputs?.getIsReadyOrError() === false)
 
-  .title(() => 'Immune Assay Data')
+  .title(() => 'Sequence Assay Data')
 
   .subtitle((ctx) => ctx.data.customBlockLabel || deriveDefaultLabel(ctx.data))
 

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -14,6 +14,8 @@ export type Settings = {
   similarityType: 'sequence-identity' | 'alignment-score';
 };
 
+export type Modality = 'antibody_tcr' | 'peptide';
+
 export type ImportColumnInfo = {
   header: string;
   type: 'Int' | 'Double' | 'String';
@@ -39,6 +41,12 @@ export type BlockData = {
   fileImportError?: string;
   tableState: PlDataTableStateV2;
   alignmentModel: PlMultiSequenceAlignmentModel;
+  /**
+   * Last modality the UI applied defaults for. Modality-change reset (R5) fires
+   * only when `outputs.modality` differs from this value, so picking a different
+   * dataset of the same modality preserves user-tuned thresholds.
+   */
+  lastAppliedModality?: Modality;
 };
 
 /** Projected args consumed by the main workflow. */

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -41,11 +41,7 @@ export type BlockData = {
   fileImportError?: string;
   tableState: PlDataTableStateV2;
   alignmentModel: PlMultiSequenceAlignmentModel;
-  /**
-   * Last modality the UI applied defaults for. Modality-change reset (R5) fires
-   * only when `outputs.modality` differs from this value, so picking a different
-   * dataset of the same modality preserves user-tuned thresholds.
-   */
+  // Last modality the UI applied defaults for
   lastAppliedModality?: Modality;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.8.0
-      version: 2.8.0
+      specifier: 2.8.2
+      version: 2.8.2
     '@platforma-sdk/blocks-deps-updater':
       specifier: 2.2.0
       version: 2.2.0
@@ -88,7 +88,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       '@platforma-sdk/blocks-deps-updater':
         specifier: 'catalog:'
         version: 2.2.0
@@ -113,7 +113,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
 
   model:
     dependencies:
@@ -135,7 +135,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.0
+        version: 2.8.2
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.27.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.27.0)(typescript@5.6.3))(eslint-plugin-n@17.18.0(eslint@9.27.0))(eslint-plugin-vue@9.33.0(eslint@9.27.0))(eslint@9.27.0)(globals@15.15.0)(typescript-eslint@8.32.1(eslint@9.27.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -1024,6 +1024,10 @@ packages:
     resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.8.1':
+    resolution: {integrity: sha512-x2Y1xooxtEttIfj60JSGMUDdTsAk3RrmlOmuuytwgq82RfDpAAa1M1XHBfuCUNoAjDP1e6BgU9rk4ZhOMGBf9A==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
@@ -1032,6 +1036,9 @@ packages:
 
   '@milaboratories/pl-model-backend@1.3.0':
     resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    resolution: {integrity: sha512-1w4Jcl2vk7w8foWztKthDryQCPrkefW+5hXIwSNsNIB40o0v83p4zoqMGBrrm9b2MJUPoFyliTkAsp+J1UQu9g==}
 
   '@milaboratories/pl-model-common@1.42.0':
     resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
@@ -1382,8 +1389,8 @@ packages:
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3':
     resolution: {integrity: sha512-npV+3LXmQNaX5/QsqtsRr5i0oLG7Uu5p51pI27WA2AbN2iyEUbHwbELhEwU26rkdzKTukCvCzs3NTuxIxQy7vQ==}
 
-  '@platforma-sdk/block-tools@2.8.0':
-    resolution: {integrity: sha512-3IjwEz4grmpA6Xxrpsg4jkKqvasMUofEiyKAnWs4uXAj+IR5BI18yS8Rc1Akzz2TOgq0qvFcRqjElb7Qfg3CpA==}
+  '@platforma-sdk/block-tools@2.8.2':
+    resolution: {integrity: sha512-9+rqqx0XAWNfo+P6rA95UqRFMLZckbZ3W/xPi53zt+vYqgCLehZM+KnGROOk0w5NxiTsudB2JJSbeM2WyQUnxQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -6963,6 +6970,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.0
 
+  '@milaboratories/pl-client@3.8.1':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.0
+
   '@milaboratories/pl-error-like@1.12.10':
     dependencies:
       json-stringify-safe: 5.0.1
@@ -6975,6 +7000,12 @@ snapshots:
   '@milaboratories/pl-model-backend@1.3.0':
     dependencies:
       '@milaboratories/pl-client': 3.7.0
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-backend@1.3.2':
+    dependencies:
+      '@milaboratories/pl-client': 3.8.1
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -7299,11 +7330,11 @@ snapshots:
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3': {}
 
-  '@platforma-sdk/block-tools@2.8.0':
+  '@platforma-sdk/block-tools@2.8.2':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.0
+      '@milaboratories/pl-model-backend': 1.3.2
       '@milaboratories/pl-model-common': 1.42.0
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.77.4
   '@platforma-sdk/tengo-builder': 3.0.0
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.0
+  '@platforma-sdk/block-tools': 2.8.2
   '@platforma-sdk/eslint-config': 1.2.0
   '@platforma-sdk/test': 1.77.4
   '@milaboratories/helpers': 1.14.2

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { PlMultiSequenceAlignment } from '@milaboratories/multi-sequence-alignment';
+import strings from '@milaboratories/strings';
+import { getDefaultBlockLabel, type Settings } from '@platforma-open/milaboratories.immune-assay-data.model';
 import type {
   AxisId,
   ImportFileHandle,
@@ -12,13 +14,12 @@ import {
   getRawPlatformaInstance,
   isImportFileHandleUpload,
 } from '@platforma-sdk/model';
-import { getDefaultBlockLabel, type Settings } from '@platforma-open/milaboratories.immune-assay-data.model';
 import {
+  PlAccordionSection,
   PlAgDataTableV2,
   PlAlert,
   PlBlockPage,
   PlBtnGhost,
-  PlAccordionSection,
   PlCheckbox,
   PlDropdown,
   PlDropdownMulti,
@@ -32,7 +33,6 @@ import {
   ReactiveFileContent,
   usePlDataTableSettingsV2,
 } from '@platforma-sdk/ui-vue';
-import strings from '@milaboratories/strings';
 import {
   computed,
   reactive,
@@ -83,11 +83,6 @@ watch(
 );
 
 // Apply modality-aware threshold defaults when the resolved modality flips.
-// `lastAppliedModality` guards the watcher so picking a different dataset of
-// the same modality preserves user-tuned thresholds. The harness flags any
-// `outputs → data` watcher as a hairpin; the multi-client write race is muted
-// here because both clients compute identical writes (same modality → same
-// defaults constant), making the writes idempotent.
 watch(
   () => app.model.outputs.modality,
   (modality) => {

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -12,7 +12,7 @@ import {
   getRawPlatformaInstance,
   isImportFileHandleUpload,
 } from '@platforma-sdk/model';
-import { getDefaultBlockLabel } from '@platforma-open/milaboratories.immune-assay-data.model';
+import { getDefaultBlockLabel, type Settings } from '@platforma-open/milaboratories.immune-assay-data.model';
 import {
   PlAgDataTableV2,
   PlAlert,
@@ -53,6 +53,12 @@ import {
 const app = useApp();
 const reactiveFileContent = ReactiveFileContent.useGlobal();
 
+// Modality-aware threshold defaults. Applied by the watcher below when the
+// resolved modality changes; switching between two datasets of the same
+// modality preserves user-tuned thresholds.
+const ANTIBODY_DEFAULTS: Settings = { similarityType: 'alignment-score', identity: 0.9, coverageThreshold: 0.95 };
+const PEPTIDE_DEFAULTS: Settings = { similarityType: 'sequence-identity', identity: 1.0, coverageThreshold: 1.0 };
+
 const defaultLabel = computed(() =>
   getDefaultBlockLabel({
     fileName: app.model.data.fileHandle ? getFileNameFromHandle(app.model.data.fileHandle) : undefined,
@@ -76,6 +82,22 @@ watch(
   },
 );
 
+// Apply modality-aware threshold defaults when the resolved modality flips.
+// `lastAppliedModality` guards the watcher so picking a different dataset of
+// the same modality preserves user-tuned thresholds. The harness flags any
+// `outputs → data` watcher as a hairpin; the multi-client write race is muted
+// here because both clients compute identical writes (same modality → same
+// defaults constant), making the writes idempotent.
+watch(
+  () => app.model.outputs.modality,
+  (modality) => {
+    if (!modality) return;
+    if (app.model.data.lastAppliedModality === modality) return;
+    app.model.data.settings = modality === 'peptide' ? PEPTIDE_DEFAULTS : ANTIBODY_DEFAULTS;
+    app.model.data.lastAppliedModality = modality;
+  },
+);
+
 const tableSettings = usePlDataTableSettingsV2({
   model: () => app.model.outputs.table,
 });
@@ -95,13 +117,13 @@ const assayAxis = computed<AxisId>(() => {
   if (app.model.outputs.assaySequenceSpec?.axesSpec[0] === undefined) {
     return {
       type: 'String',
-      name: 'pl7.app/vdj/assay/sequenceId',
+      name: 'pl7.app/assay/sequenceId',
       domain: {},
     };
   } else {
     return {
       type: 'String',
-      name: 'pl7.app/vdj/assay/sequenceId',
+      name: 'pl7.app/assay/sequenceId',
       domain: app.model.outputs.assaySequenceSpec.axesSpec[0].domain,
     };
   }
@@ -241,7 +263,7 @@ const similarityTypeOptions = [
   <PlBlockPage
     v-model:subtitle="app.model.data.customBlockLabel"
     :subtitle-placeholder="defaultLabel"
-    title="Immune Assay Data"
+    title="Sequence Assay Data"
   >
     <template #append>
       <PlBtnGhost
@@ -259,7 +281,7 @@ const similarityTypeOptions = [
     </template>
     <PlAlert v-if="app.model.outputs.emptyClonesInput === true" type="warn" icon>
       <template #title>Empty dataset selection</template>
-      The input dataset you have selected is empty or has no clonotype sequences.
+      The input dataset you have selected is empty or has no sequences.
       Please choose a different dataset or check your input data.
     </PlAlert>
     <PlAgDataTableV2
@@ -284,12 +306,12 @@ const similarityTypeOptions = [
       />
       <PlDropdown
         v-model="app.model.data.targetRef" :options="app.model.outputs.targetOptions"
-        label="Clonotype sequence to match" clearable required
+        label="Sequence column to match" clearable required
       >
         <template #tooltip>
-          Select the sequence column used to match the assay data sequence with. If you select amino acid sequence and
-          the assay data sequence is nucleotide, the assay data sequence will be converted to amino acid sequence
-          automatically.
+          Select the sequence column to align against the assay sequences. If the alphabets differ
+          (e.g., amino acid input vs nucleotide assay), MMseqs2 translates automatically using the
+          appropriate search mode.
         </template>
       </PlDropdown>
       <PlFileInput
@@ -351,7 +373,8 @@ const similarityTypeOptions = [
         :max-value="1.0"
       >
         <template #tooltip>
-          Select min fraction of aligned (covered) residues of clonotypes in the cluster.
+          Minimum fraction of residues that must align between the input sequence and the assay
+          sequence to count as a match.
         </template>
       </PlNumberField>
 

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -1,27 +1,27 @@
-import type { PColumnPredicate, PColumnSpec } from '@platforma-sdk/model';
-import { Annotation, Domain, PAxisName, PColumnName, readAnnotationJson, readDomain } from '@platforma-sdk/model';
+import type { PColumnPredicate } from '@platforma-sdk/model';
+import { Annotation, Domain, PAxisName, readAnnotationJson, readDomain } from '@platforma-sdk/model';
 
 export const isAssayColumn: PColumnPredicate = ({ spec }) =>
-  spec.name === PColumnName.VDJ.Sequence
-  && spec.axesSpec[0].name === PAxisName.VDJ.Assay.SequenceId;
+  spec.name === 'pl7.app/sequence'
+  && spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId';
 
 export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
-  const isBulkSequence = (spec: PColumnSpec) =>
-    spec.name !== 'pl7.app/vdj/sequenceLength'
-    && spec.name !== 'pl7.app/vdj/sequence/annotation'
-    && spec.axesSpec[0].name !== PAxisName.VDJ.Assay.SequenceId
-    && readDomain(spec, Domain.Alphabet) === 'aminoacid';
-
-  const isSingleCellSequence = (spec: PColumnSpec) =>
-    spec.name !== 'pl7.app/vdj/sequenceLength'
-    && spec.name !== 'pl7.app/vdj/sequence/annotation'
-    && readDomain(spec, Domain.VDJ.ScClonotypeChain.Index) === 'primary'
-    && readDomain(spec, Domain.Alphabet) === 'aminoacid'
-    // && column.axesSpec.length >= 1
-    && spec.axesSpec[0].name === PAxisName.VDJ.ScClonotypeKey;
-
-  return (isBulkSequence(spec) || isSingleCellSequence(spec))
-    && {
-      default: readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature) ?? false,
-    };
+  if (spec.name === 'pl7.app/vdj/sequenceLength' || spec.name === 'pl7.app/vdj/sequence/annotation') return false;
+  if (spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId') return false;
+  if (readDomain(spec, Domain.Alphabet) !== 'aminoacid') return false;
+  if (
+    spec.axesSpec[0]?.name === PAxisName.VDJ.ScClonotypeKey
+    && readDomain(spec, Domain.VDJ.ScClonotypeChain.Index) !== 'primary'
+  ) {
+    return false;
+  }
+  // `readAnnotationJson` enforces a runtime schema lookup that fails for keys not
+  // registered in the SDK's AnnotationJson map; the error is caught upstream and
+  // returns undefined. So we read the neutral form by direct annotation access
+  // until the SDK ships a typed constant for it.
+  // TODO: replace direct access with `readAnnotationJson(spec, Annotation.IsAssemblingFeature)` after SDK rename.
+  const isAssemblingFeature
+    = readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature)
+      ?? spec.annotations?.['pl7.app/isAssemblingFeature'] === 'true';
+  return { default: isAssemblingFeature };
 };

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -19,10 +19,6 @@ export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
   ) {
     return false;
   }
-  // `readAnnotationJson` enforces a runtime schema lookup that fails for keys not
-  // registered in the SDK's AnnotationJson map; the error is caught upstream and
-  // returns undefined. So we read the neutral form by direct annotation access
-  // until the SDK ships a typed constant for it.
   // TODO: replace direct access with `readAnnotationJson(spec, Annotation.IsAssemblingFeature)` after SDK rename.
   const isAssemblingFeature
     = readAnnotationJson(spec, Annotation.VDJ.IsAssemblingFeature)

--- a/ui/src/util.ts
+++ b/ui/src/util.ts
@@ -6,7 +6,11 @@ export const isAssayColumn: PColumnPredicate = ({ spec }) =>
   && spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId';
 
 export const isSequenceColumn: PColumnPredicate = ({ spec }) => {
-  if (spec.name === 'pl7.app/vdj/sequenceLength' || spec.name === 'pl7.app/vdj/sequence/annotation') return false;
+  if (
+    spec.name === 'pl7.app/vdj/sequenceLength'
+    || spec.name === 'pl7.app/sequenceLength'
+    || spec.name === 'pl7.app/vdj/sequence/annotation'
+  ) return false;
   if (spec.axesSpec[0]?.name === 'pl7.app/assay/sequenceId') return false;
   if (readDomain(spec, Domain.Alphabet) !== 'aminoacid') return false;
   if (

--- a/workflow/src/analysis.tpl.tengo
+++ b/workflow/src/analysis.tpl.tengo
@@ -278,7 +278,9 @@ self.body(func(args) {
 		similarityType: similarityType,
 		clonesFasta: chunk1Fasta,
 		assayFasta: assayFasta,
-		lessSensitive: lessSensitive
+		lessSensitive: lessSensitive,
+		isPeptide: args.isPeptide,
+		minPeptideLength: args.minPeptideLength
 	}, {
 		metaInputs: {
 			mem: mem,
@@ -293,7 +295,9 @@ self.body(func(args) {
 		similarityType: similarityType,
 		clonesFasta: chunk2Fasta,
 		assayFasta: assayFasta,
-		lessSensitive: lessSensitive
+		lessSensitive: lessSensitive,
+		isPeptide: args.isPeptide,
+		minPeptideLength: args.minPeptideLength
 	}, {
 		metaInputs: {
 			mem: mem,

--- a/workflow/src/build-outputs.tpl.tengo
+++ b/workflow/src/build-outputs.tpl.tengo
@@ -15,6 +15,15 @@ assayColumnName := func(header) {
 }
 
 self.body(func(inputs) {
+	// Display labels reflect what the upstream actually carries — clones for
+	// VDJ, peptides for peptide-extraction. Column/axis `name`s stay neutral
+	// (`pl7.app/assay/*`); labels diverge because the upstream-side semantics
+	// differ: queryCount counts clones vs peptides, and the linker column's
+	// `target` axis is `clonotypeKey` vs `variantKey` — different identities.
+	isPeptide := inputs.datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	matchedCountLabel := isPeptide ? "Matched Peptides" : "Matched Clones"
+	linkerLabel := isPeptide ? "Peptide to assay link" : "Clone to assay link"
+
 	//////// Building outputs & exports ////////
 	assayColumns := [
 		{
@@ -27,14 +36,14 @@ self.body(func(inputs) {
 					"pl7.app/table/fontFamily": "monospace"
 				}
 			}
-		},	
+		},
 		{
 			column: "queryCount",
 			spec: {
 				name: "pl7.app/assay/queryCount",
 				valueType: "Int",
 				annotations: {
-					"pl7.app/label": "Matched Clones",
+					"pl7.app/label": matchedCountLabel,
 					"pl7.app/table/orderPriority": "9000"
 				}
 			}
@@ -214,7 +223,7 @@ self.body(func(inputs) {
 					valueType: "Int",
 					annotations: {
 						"pl7.app/isLinkerColumn": "true",
-						"pl7.app/label": "Clone to assay link",
+						"pl7.app/label": linkerLabel,
 						"pl7.app/table/visibility": "hidden"
 					}
 				}

--- a/workflow/src/build-outputs.tpl.tengo
+++ b/workflow/src/build-outputs.tpl.tengo
@@ -11,7 +11,7 @@ self.awaitState("assaySequenceType", "ResourceReady")
 self.awaitState("sequenceColumnInfo", "ResourceReady")
 
 assayColumnName := func(header) {
-	return "pl7.app/vdj/assay-data/" + strings.substituteSpecialCharacters(header)
+	return "pl7.app/assay-data/" + strings.substituteSpecialCharacters(header)
 }
 
 self.body(func(inputs) {
@@ -31,19 +31,19 @@ self.body(func(inputs) {
 		{
 			column: "queryCount",
 			spec: {
-				name: "pl7.app/vdj/assay/queryCount",
+				name: "pl7.app/assay/queryCount",
 				valueType: "Int",
 				annotations: {
 					"pl7.app/label": "Matched Clones",
 					"pl7.app/table/orderPriority": "9000"
 				}
 			}
-		},	
+		},
 		{
 			column: inputs.sequenceColumnInfo.header,
 			id: strings.substituteSpecialCharacters(inputs.sequenceColumnInfo.header),
 			spec: {
-				name: "pl7.app/vdj/sequence",
+				name: "pl7.app/sequence",
 				valueType: "String",
 				domain: {
 					"pl7.app/alphabet": inputs.assaySequenceType
@@ -79,7 +79,7 @@ self.body(func(inputs) {
 		axes: [{
 			column: "seqId",
 			spec: {
-				name: "pl7.app/vdj/assay/sequenceId",
+				name: "pl7.app/assay/sequenceId",
 				type: "String",
 				domain: {
 					"pl7.app/blockId": inputs.blockId
@@ -100,7 +100,7 @@ self.body(func(inputs) {
 	{
 		column: "seqIdLabel",
 		spec: {
-			name: "pl7.app/vdj/assay/sequenceIdLabel",
+			name: "pl7.app/assay/sequenceIdLabel",
 			valueType: "String",
 			annotations: {
 				"pl7.app/label": "Assay Sequence Id",
@@ -195,7 +195,7 @@ self.body(func(inputs) {
 				{
 					column: "query",
 					spec: {
-						name: "pl7.app/vdj/assay/sequenceId",
+						name: "pl7.app/assay/sequenceId",
 						type: "String",
 						domain: {
 							"pl7.app/blockId": inputs.blockId
@@ -210,7 +210,7 @@ self.body(func(inputs) {
 			columns: [{
 				column: "link",
 				spec: {
-					name: "pl7.app/vdj/link",
+					name: "pl7.app/link",
 					valueType: "Int",
 					annotations: {
 						"pl7.app/isLinkerColumn": "true",

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -23,8 +23,15 @@ checkContentEmptySw := assets.importSoftware("@platforma-open/milaboratories.imm
 
 wf.prepare(func(args){
 	bundleBuilder := wf.createPBundleBuilder()
-	bundleBuilder.addAnchor("main", args.datasetRef) 
+	bundleBuilder.addAnchor("main", args.datasetRef)
 	bundleBuilder.addSingle(args.targetRef)
+	// Peptide-only: per-peptide length column drives the short-peptide k-mer
+	// override in run-alignment. Empty bundle slot on VDJ inputs.
+	bundleBuilder.addMulti({
+		axes: [{ anchor: "main", idx: 1 }],
+		name: "pl7.app/sequenceLength",
+		domain: { "pl7.app/feature": "peptide" }
+	}, "peptideSequenceLength")
 	return {
 		columns: bundleBuilder.build()
 	}
@@ -48,6 +55,45 @@ wf.body(func(args) {
 	importFile := file.importFile(args.fileHandle)
 	datasetSpec := args.columns.getSpec(args.datasetRef)
 	targetSpec := args.columns.getSpec(args.targetRef)
+
+	// Detect peptide modality and compute min peptide length when applicable.
+	// Drives the short-peptide k-mer override in run-alignment (k=5 + relaxed
+	// mmseqs2 prefilter for inputs below the auto-tune floor of ~6).
+	isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	minPeptideLength := undefined
+	if isPeptide {
+		peptideLenCols := args.columns.getColumns("peptideSequenceLength")
+		if len(peptideLenCols) == 0 {
+			ll.panic("Peptide input is missing required pl7.app/sequenceLength column")
+		}
+		// Peptide-extraction emits both aa and nt length columns under the same
+		// name + feature domain; pick the one matching the target's alphabet so
+		// the k-mer threshold reflects the actual search-side sequence length.
+		targetAlphabet := targetSpec.domain["pl7.app/alphabet"]
+		matchedLenCol := undefined
+		for col in peptideLenCols {
+			if col.spec.domain["pl7.app/alphabet"] == targetAlphabet {
+				matchedLenCol = col
+				break
+			}
+		}
+		if is_undefined(matchedLenCol) {
+			ll.panic("No peptide length column matches target alphabet: ", targetAlphabet)
+		}
+		// pt's `min` is a window function — bare `select(min())` doesn't fold the
+		// whole frame. Use `groupBy` with a constant key to aggregate across all
+		// rows. Filter `len > 0` because peptide-extraction emits 0-length rows
+		// for some variants (see peptide-extraction/compute-qc-sample.tpl.tengo:60).
+		minLenWf := pt.workflow()
+		minLenWf.frame(pt.p.column("len", { spec: matchedLenCol.spec, data: matchedLenCol.data })).
+			filter(pt.col("len").gt(pt.lit(0))).
+			withColumns(pt.lit(1).alias("_g")).
+			groupBy("_g").
+			agg(pt.col("len").min().alias("min_len")).
+			saveContent("min_len.ndjson")
+		minLenResult := minLenWf.run()
+		minPeptideLength = minLenResult.getFileContent("min_len.ndjson")
+	}
 	
 	// aminoacid or nucleotide
 	sequenceColumnInfo := undefined
@@ -141,7 +187,9 @@ wf.body(func(args) {
 		similarityType: args.settings.similarityType,
 		lessSensitive: args.lessSensitive,
 		importColumns: args.importColumns,
-		selectedColumns: args.selectedColumns
+		selectedColumns: args.selectedColumns,
+		isPeptide: isPeptide,
+		minPeptideLength: minPeptideLength
 	}, {
 		metaInputs: {
 			mem: args.mem,

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -80,16 +80,9 @@ wf.body(func(args) {
 		if is_undefined(matchedLenCol) {
 			ll.panic("No peptide length column matches target alphabet: ", targetAlphabet)
 		}
-		// pt's `min` is a window function — bare `select(min())` doesn't fold the
-		// whole frame. Use `groupBy` with a constant key to aggregate across all
-		// rows. Filter `len > 0` because peptide-extraction emits 0-length rows
-		// for some variants (see peptide-extraction/compute-qc-sample.tpl.tengo:60).
 		minLenWf := pt.workflow()
 		minLenWf.frame(pt.p.column("len", { spec: matchedLenCol.spec, data: matchedLenCol.data })).
-			filter(pt.col("len").gt(pt.lit(0))).
-			withColumns(pt.lit(1).alias("_g")).
-			groupBy("_g").
-			agg(pt.col("len").min().alias("min_len")).
+			select(pt.col("len").min().alias("min_len")).
 			saveContent("min_len.ndjson")
 		minLenResult := minLenWf.run()
 		minPeptideLength = minLenResult.getFileContent("min_len.ndjson")

--- a/workflow/src/run-alignment.tpl.tengo
+++ b/workflow/src/run-alignment.tpl.tengo
@@ -52,8 +52,58 @@ self.body(func(args) {
 		mmseqs = mmseqs.
 			arg("--comp-bias-corr").arg("0").
 			arg("--mask").arg("0").
-			arg("--exact-kmer-matching").arg("1").
-			arg("-k").arg("7")
+			arg("--exact-kmer-matching").arg("1")
+		// -k determined below: peptide-min-length override may win over Fast mode's k=7.
+	}
+
+	// MMseqs2's `-k 0` auto-tune floors at ~6 and Fast mode's `-k 7` has the
+	// same problem: sub-k-aa peptides produce zero k-mers and silently miss
+	// every match (no error, just empty results). Force `-k 5` whenever the
+	// shortest input peptide is below 10 aa, taking precedence over Fast mode.
+	//
+	// The spec called only for `-k 5`, but empirically that's not enough —
+	// MMseqs2 has several other defaults that quietly filter short alignments,
+	// so the additional flags below mirror clonotype-clustering's
+	// "highPrecision" mode (clonotype-clustering/workflow/src/clustering.tpl.tengo)
+	// which solves the same problem for short CDRs.
+	isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
+	shortPeptide := false
+	if isPeptide && !is_undefined(args.minPeptideLength) {
+		parsed := args.minPeptideLength.getDataAsJson()
+		ml := int(parsed.min_len)
+		if ml < 10 {
+			shortPeptide = true
+		}
+	}
+	kValue := undefined
+	if shortPeptide {
+		kValue = "5"
+		mmseqs = mmseqs.
+			// Default `--spaced-kmer-mode 1` (spaced k-mers) requires informative
+			// positions spread over a span longer than k, so with k=5 and a
+			// 7-aa peptide no valid k-mer can be formed. `0` switches to
+			// consecutive k-mers so every length-k substring is a candidate hit.
+			arg("--spaced-kmer-mode").arg("0").
+			// Default `--min-ungapped-score 15` filters very short alignments
+			// after the k-mer prefilter. For sub-7-aa hits BLOSUM62 ungapped
+			// scores can fall below 15 even for exact matches. `0` disables
+			// the floor.
+			arg("--min-ungapped-score").arg("0").
+			// Default `-s` is around 5.7. Higher sensitivity widens the
+			// prefilter, which we need at k=5 to ensure short-peptide hits
+			// propagate from prefilter to alignment.
+			arg("-s").arg("7.5").
+			// Default `-e 1e-3` rejects alignments with high e-value. e-value
+			// scales with database size and inversely with bit score, so even
+			// an exact 7-aa hit can exceed the threshold against a large
+			// peptide DB. `inf` removes the filter; `--min-seq-id 1.0` + full
+			// coverage already constrain the match to true exact identity.
+			arg("-e").arg("inf")
+	} else if lessSensitive {
+		kValue = "7"
+	}
+	if !is_undefined(kValue) {
+		mmseqs = mmseqs.arg("-k").arg(kValue)
 	}
 
 	mmseqs = mmseqs.

--- a/workflow/src/run-alignment.tpl.tengo
+++ b/workflow/src/run-alignment.tpl.tengo
@@ -53,19 +53,10 @@ self.body(func(args) {
 			arg("--comp-bias-corr").arg("0").
 			arg("--mask").arg("0").
 			arg("--exact-kmer-matching").arg("1")
-		// -k determined below: peptide-min-length override may win over Fast mode's k=7.
 	}
 
-	// MMseqs2's `-k 0` auto-tune floors at ~6 and Fast mode's `-k 7` has the
-	// same problem: sub-k-aa peptides produce zero k-mers and silently miss
-	// every match (no error, just empty results). Force `-k 5` whenever the
-	// shortest input peptide is below 10 aa, taking precedence over Fast mode.
-	//
-	// The spec called only for `-k 5`, but empirically that's not enough —
-	// MMseqs2 has several other defaults that quietly filter short alignments,
-	// so the additional flags below mirror clonotype-clustering's
-	// "highPrecision" mode (clonotype-clustering/workflow/src/clustering.tpl.tengo)
-	// which solves the same problem for short CDRs.
+	// MMseqs2's `-k 0` auto-tune floors at ~6, force `-k 5` whenever the
+	// shortest input peptide is below 10 aa,
 	isPeptide := is_undefined(args.isPeptide) ? false : args.isPeptide
 	shortPeptide := false
 	if isPeptide && !is_undefined(args.minPeptideLength) {
@@ -77,27 +68,12 @@ self.body(func(args) {
 	}
 	kValue := undefined
 	if shortPeptide {
+		// Set default parameters adapted for short sequences
 		kValue = "5"
 		mmseqs = mmseqs.
-			// Default `--spaced-kmer-mode 1` (spaced k-mers) requires informative
-			// positions spread over a span longer than k, so with k=5 and a
-			// 7-aa peptide no valid k-mer can be formed. `0` switches to
-			// consecutive k-mers so every length-k substring is a candidate hit.
 			arg("--spaced-kmer-mode").arg("0").
-			// Default `--min-ungapped-score 15` filters very short alignments
-			// after the k-mer prefilter. For sub-7-aa hits BLOSUM62 ungapped
-			// scores can fall below 15 even for exact matches. `0` disables
-			// the floor.
 			arg("--min-ungapped-score").arg("0").
-			// Default `-s` is around 5.7. Higher sensitivity widens the
-			// prefilter, which we need at k=5 to ensure short-peptide hits
-			// propagate from prefilter to alignment.
 			arg("-s").arg("7.5").
-			// Default `-e 1e-3` rejects alignments with high e-value. e-value
-			// scales with database size and inversely with bit score, so even
-			// an exact 7-aa hit can exceed the threshold against a large
-			// peptide DB. `inf` removes the filter; `--min-seq-id 1.0` + full
-			// coverage already constrain the match to true exact identity.
 			arg("-e").arg("inf")
 	} else if lessSensitive {
 		kValue = "7"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the block (renamed from "Immune Assay Data" to "Sequence Assay Data") to accept peptide-extraction datasets (`pl7.app/variantKey` axis) alongside bulk and single-cell VDJ clonotypes, with modality-aware MMseqs2 parameters and UI defaults.

- **Peptide modality support**: a new retentive `modality` output drives per-modality threshold defaults in the UI; the `lastAppliedModality` guard prevents clobbering user-tuned settings when switching between datasets of the same modality.
- **Short-peptide k-mer override**: when the shortest input peptide is below 10 aa, MMseqs2 is reconfigured with `-k 5 --spaced-kmer-mode 0 --min-ungapped-score 0 -s 7.5 -e inf` to avoid the silent zero-hit problem caused by the default prefilter floor.
- **Modality-neutral output names**: all emitted column/axis names (`pl7.app/vdj/*`) are renamed to neutral forms (`pl7.app/assay/*`, `pl7.app/sequence`, `pl7.app/link`), with the `queryCount` column's visible label "Matched Clones" being the one name that was not updated.
</details>

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Safe to merge with the understanding that peptide-mode output tables will show "Matched Clones" as a column header until the label is corrected.

The core modality-detection, short-peptide k-mer override, and threshold-default logic are well-structured and guarded. The main gap is the "Matched Clones" label in build-outputs.tpl.tengo — a user-visible annotation that was not updated when all other VDJ-namespaced names were made modality-neutral. For peptide users this column header is actively misleading. A secondary concern is that the neutral pl7.app/sequenceLength column (peptide length) is no longer excluded from the MSA sequence-column picker the way the old pl7.app/vdj/sequenceLength was, potentially surfacing an integer column in a sequence selector.

workflow/src/build-outputs.tpl.tengo (stale "Matched Clones" label) and ui/src/util.ts (isSequenceColumn exclusion list).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/build-outputs.tpl.tengo | Renames all emitted column/axis names to modality-neutral forms; the queryCount label "Matched Clones" was not updated, showing VDJ-specific text in peptide mode. |
| ui/src/util.ts | Rewrites isAssayColumn/isSequenceColumn predicates for neutral names; pl7.app/sequenceLength (new peptide length column) is not excluded, risking its appearance in the MSA picker. |
| workflow/src/main.tpl.tengo | Adds peptide modality detection, min-peptide-length computation via pt aggregation, and passes isPeptide/minPeptideLength to the analysis template. Logic is well-guarded with panics for missing columns. |
| workflow/src/run-alignment.tpl.tengo | Adds short-peptide k-mer override (k=5 + spaced-kmer-mode 0, min-ungapped-score 0, -s 7.5, -e inf) when min peptide length < 10 aa; lessSensitive k=7 path preserved with explicit precedence logic. |
| model/src/index.ts | Adds peptide anchor discovery, retentive modality output, per-modality targetOptions branching, and lastAppliedModality seeding in upgradeLegacy. Optional chaining on axesSpec[1] is a good defensive improvement. |
| ui/src/pages/MainPage.vue | Adds modality-aware threshold watcher with lastAppliedModality guard; updates axis names, labels, and tooltips to neutral forms. Idempotency comment for the multi-client write race is well-explained. |
| model/src/types.ts | Adds Modality type and lastAppliedModality field to BlockData with clear JSDoc explaining the modality-reset guard semantics. |
| workflow/src/analysis.tpl.tengo | Adds isPeptide and minPeptideLength pass-through to both run-alignment invocations; straightforward forwarding change. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects dataset] --> B{axesSpec 1 name?}
    B -->|pl7.app/variantKey| C[modality = peptide]
    B -->|vdj/scClonotypeKey| D[modality = antibody_tcr]
    B -->|vdj/clonotypeKey| D

    C --> E[Apply PEPTIDE_DEFAULTS\nsequence-identity / 1.0 / 1.0]
    D --> F[Apply ANTIBODY_DEFAULTS\nalignment-score / 0.9 / 0.95]

    C --> G[targetOptions: pl7.app/sequence\nfeature=peptide]
    D --> H[targetOptions: pl7.app/vdj/sequence]

    C --> I{isPeptide=true\nfetch peptideSequenceLength columns}
    I --> J[groupBy agg to min_len.ndjson]
    J --> K{min_len < 10?}
    K -->|yes| L[shortPeptide override\n-k 5 --spaced-kmer-mode 0\n--min-ungapped-score 0\n-s 7.5 -e inf]
    K -->|no| M[normal k / lessSensitive k=7]

    L --> N[MMseqs2 easy-search\nchunk 1 + chunk 2]
    M --> N
    H --> N

    N --> O[build-outputs\npl7.app/assay/* neutral names]
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
workflow/src/build-outputs.tpl.tengo:37
**Stale "Matched Clones" label for peptide modality**

The `pl7.app/label` annotation for `queryCount` was not updated when the column name was migrated from `pl7.app/vdj/assay/queryCount` to the modality-neutral `pl7.app/assay/queryCount`. In peptide mode this column header will read "Matched Clones" in the output table, which is misleading — the inputs are peptide variants, not clones. Consider "Matched Sequences" (or a modality-aware label passed in as a template input) to stay consistent with the rest of the modality-neutral rename described in the changeset.

### Issue 2 of 2
ui/src/util.ts:9-10
**Neutral `pl7.app/sequenceLength` not excluded from sequence column picker**

The old predicate explicitly excluded `pl7.app/vdj/sequenceLength`; the new code preserves that exclusion but does not exclude `pl7.app/sequenceLength` (the neutral name now used by peptide-extraction for its per-peptide length column). Peptide-extraction length columns carry `pl7.app/alphabet: aminoacid` in their domain, so `readDomain(spec, Domain.Alphabet) !== 'aminoacid'` won't filter them. They pass all remaining checks and would appear in the MSA sequence-column picker (with `default: false`), showing an integer length column as a selectable sequence source. Adding `spec.name === 'pl7.app/sequenceLength'` to the early-return guard mirrors the existing VDJ exclusion.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6255: Accept peptide datasets; ren..."](https://github.com/platforma-open/immune-assay-data/commit/baeb04e02bc7b1563700f2df46ac9a2b23b5fa67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33301984)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->