### PR TITLE
Introduce sequence identity matching mode

### DIFF
--- a/.changeset/exact-match-mode.md
+++ b/.changeset/exact-match-mode.md
@@ -1,8 +1,9 @@
 ---
+'@platforma-open/milaboratories.immune-assay-data.sequence-match': minor
 '@platforma-open/milaboratories.immune-assay-data.workflow': minor
 '@platforma-open/milaboratories.immune-assay-data.model': minor
 '@platforma-open/milaboratories.immune-assay-data.ui': minor
 '@platforma-open/milaboratories.immune-assay-data': minor
 ---
 
-Add "Identical sequences" matching mode — a recall-guaranteed exact (byte-identical) match that bypasses MMseqs2 alignment. Selectable in the Alignment Score dropdown; hides the MMseqs2-only controls (score/coverage thresholds, fast mode) and is gated to same-alphabet assay/target pairs.
+Add "Sequence Match" matching mode — a recall-guaranteed, alignment-free match that reports every target containing an assay sequence as an exact substring (the deterministic equivalent of an MMseqs2 id=1/cov=1 search). Implemented in a new `sequence-match` Python software package using polars' Aho-Corasick scan. Exposed via a top-level "Matching mode" control (Alignment vs Sequence Match); Sequence Match hides the MMseqs2-only controls and is gated to same-alphabet assay/target pairs.

--- a/.changeset/exact-match-mode.md
+++ b/.changeset/exact-match-mode.md
@@ -1,0 +1,8 @@
+---
+'@platforma-open/milaboratories.immune-assay-data.workflow': minor
+'@platforma-open/milaboratories.immune-assay-data.model': minor
+'@platforma-open/milaboratories.immune-assay-data.ui': minor
+'@platforma-open/milaboratories.immune-assay-data': minor
+---
+
+Add "Identical sequences" matching mode — a recall-guaranteed exact (byte-identical) match that bypasses MMseqs2 alignment. Selectable in the Alignment Score dropdown; hides the MMseqs2-only controls (score/coverage thresholds, fast mode) and is gated to same-alphabet assay/target pairs.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -111,6 +111,11 @@ export const platforma = BlockModelV3.create(blockDataModel)
     if (data.sequenceColumnHeader === undefined) throw new Error('Assay sequence column is required');
     if (data.fileImportError !== undefined) throw new Error(data.fileImportError);
 
+    // In exact-match mode the MMseqs2-only parameters carry no meaning. Pin
+    // them so editing a hidden threshold (or toggling fast mode) does not
+    // stale the block.
+    const exact = data.settings.similarityType === 'exact-match';
+
     return {
       defaultBlockLabel: deriveDefaultLabel(data),
       customBlockLabel: data.customBlockLabel,
@@ -121,8 +126,10 @@ export const platforma = BlockModelV3.create(blockDataModel)
       importColumns: data.importColumns,
       sequenceColumnHeader: data.sequenceColumnHeader,
       selectedColumns: data.selectedColumns,
-      settings: data.settings,
-      lessSensitive: data.lessSensitive,
+      settings: exact
+        ? { similarityType: 'exact-match', identity: 1, coverageThreshold: 1 }
+        : data.settings,
+      lessSensitive: exact ? false : data.lessSensitive,
       mem: data.mem,
       cpu: data.cpu,
     };
@@ -196,6 +203,44 @@ export const platforma = BlockModelV3.create(blockDataModel)
           includeNativeLabel: true,
         },
       });
+  })
+
+  // Alphabet of the currently-selected target sequence column. Used by the UI
+  // to gate the "Identical sequences" (exact) option: exact equality cannot
+  // match across alphabets (MMseqs2 handles that via translated search; exact
+  // mode is same-alphabet only). Returns undefined while unresolved — the UI
+  // gate is permissive and the workflow asserts as the hard backstop.
+  .output('targetSequenceType', (ctx): 'nucleotide' | 'aminoacid' | undefined => {
+    const ref = ctx.data.datasetRef;
+    const targetRef = ctx.data.targetRef;
+    if (ref === undefined || targetRef === undefined) return undefined;
+
+    const datasetAxis = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name;
+    const sequenceMatchers = [];
+    if (datasetAxis === 'pl7.app/variantKey') {
+      sequenceMatchers.push({
+        axes: [{ anchor: 'main', idx: 1 }],
+        name: 'pl7.app/sequence',
+        domain: { 'pl7.app/feature': 'peptide' },
+      });
+    } else if (datasetAxis === 'pl7.app/vdj/scClonotypeKey') {
+      sequenceMatchers.push({
+        axes: [{ anchor: 'main', idx: 1 }],
+        name: 'pl7.app/vdj/sequence',
+        domain: { 'pl7.app/vdj/scClonotypeChain/index': 'primary' },
+      });
+    } else {
+      sequenceMatchers.push({
+        axes: [{ anchor: 'main', idx: 1 }],
+        name: 'pl7.app/vdj/sequence',
+        domain: {},
+      });
+    }
+
+    const cols = ctx.resultPool.getAnchoredPColumns({ main: ref }, sequenceMatchers);
+    const alphabet = cols?.find((c) => (c.id as string) === (targetRef as string))
+      ?.spec.domain?.['pl7.app/alphabet'];
+    return alphabet === 'nucleotide' || alphabet === 'aminoacid' ? alphabet : undefined;
   })
 
   .output(

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -206,40 +206,23 @@ export const platforma = BlockModelV3.create(blockDataModel)
   })
 
   // Alphabet of the currently-selected target sequence column. Used by the UI
-  // to gate the "Identical sequences" (exact) option: exact equality cannot
-  // match across alphabets (MMseqs2 handles that via translated search; exact
-  // mode is same-alphabet only). Returns undefined while unresolved — the UI
-  // gate is permissive and the workflow asserts as the hard backstop.
+  // to gate the Sequence Match option: substring matching cannot work across
+  // alphabets (MMseqs2 handles that via translated search; Sequence Match is
+  // same-alphabet only). Returns undefined while unresolved — the UI gate is
+  // permissive and the workflow asserts as the hard backstop.
+  //
+  // `targetRef` is an SUniversalPColumnId — a JSON-serialized anchored selector,
+  // not a PlRef — so it is resolved by parsing it and passing it straight to
+  // getAnchoredPColumns as the selector (idiom from clonotype-space). It cannot
+  // go through getPColumnSpecByRef, which takes a PlRef.
   .output('targetSequenceType', (ctx): 'nucleotide' | 'aminoacid' | undefined => {
-    const ref = ctx.data.datasetRef;
+    const datasetRef = ctx.data.datasetRef;
     const targetRef = ctx.data.targetRef;
-    if (ref === undefined || targetRef === undefined) return undefined;
+    if (datasetRef === undefined || targetRef === undefined) return undefined;
 
-    const datasetAxis = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name;
-    const sequenceMatchers = [];
-    if (datasetAxis === 'pl7.app/variantKey') {
-      sequenceMatchers.push({
-        axes: [{ anchor: 'main', idx: 1 }],
-        name: 'pl7.app/sequence',
-        domain: { 'pl7.app/feature': 'peptide' },
-      });
-    } else if (datasetAxis === 'pl7.app/vdj/scClonotypeKey') {
-      sequenceMatchers.push({
-        axes: [{ anchor: 'main', idx: 1 }],
-        name: 'pl7.app/vdj/sequence',
-        domain: { 'pl7.app/vdj/scClonotypeChain/index': 'primary' },
-      });
-    } else {
-      sequenceMatchers.push({
-        axes: [{ anchor: 'main', idx: 1 }],
-        name: 'pl7.app/vdj/sequence',
-        domain: {},
-      });
-    }
-
-    const cols = ctx.resultPool.getAnchoredPColumns({ main: ref }, sequenceMatchers);
-    const alphabet = cols?.find((c) => (c.id as string) === (targetRef as string))
-      ?.spec.domain?.['pl7.app/alphabet'];
+    const colId = JSON.parse(targetRef) as never;
+    const spec = ctx.resultPool.getAnchoredPColumns({ main: datasetRef }, [colId])?.[0]?.spec;
+    const alphabet = spec?.domain?.['pl7.app/alphabet'];
     return alphabet === 'nucleotide' || alphabet === 'aminoacid' ? alphabet : undefined;
   })
 

--- a/model/src/label.ts
+++ b/model/src/label.ts
@@ -1,6 +1,6 @@
 export function getDefaultBlockLabel(data: {
   fileName?: string;
-  similarityType: 'alignment-score' | 'sequence-identity';
+  similarityType: 'alignment-score' | 'sequence-identity' | 'exact-match';
   identity: number;
   coverageThreshold: number;
 }) {
@@ -9,6 +9,12 @@ export function getDefaultBlockLabel(data: {
   // Add file name if available
   if (data.fileName) {
     parts.push(data.fileName);
+  }
+
+  // Exact-match mode has no identity/coverage thresholds — they are meaningless.
+  if (data.similarityType === 'exact-match') {
+    parts.push('Identical sequences');
+    return parts.filter(Boolean).join(', ');
   }
 
   // Add similarity type label

--- a/model/src/label.ts
+++ b/model/src/label.ts
@@ -11,9 +11,9 @@ export function getDefaultBlockLabel(data: {
     parts.push(data.fileName);
   }
 
-  // Exact-match mode has no identity/coverage thresholds — they are meaningless.
+  // Sequence Match mode has no identity/coverage thresholds — they are meaningless.
   if (data.similarityType === 'exact-match') {
-    parts.push('Identical sequences');
+    parts.push('Sequence match');
     return parts.filter(Boolean).join(', ');
   }
 

--- a/model/src/types.ts
+++ b/model/src/types.ts
@@ -11,7 +11,12 @@ export type Settings = {
   coverageThreshold: number;
   /** Identity threshold (0-1). */
   identity: number;
-  similarityType: 'sequence-identity' | 'alignment-score';
+  /**
+   * Matching method. `alignment-score`/`sequence-identity` run MMseqs2;
+   * `exact-match` reports only byte-identical sequences (no alignment,
+   * guaranteed recall) and ignores identity/coverage/fast-mode.
+   */
+  similarityType: 'sequence-identity' | 'alignment-score' | 'exact-match';
 };
 
 export type Modality = 'antibody_tcr' | 'peptide';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,14 +13,14 @@ catalogs:
       specifier: ^2.29.8
       version: 2.29.8
     '@milaboratories/graph-maker':
-      specifier: 1.4.3
-      version: 1.4.3
+      specifier: 1.4.4
+      version: 1.4.4
     '@milaboratories/helpers':
       specifier: 1.14.2
       version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
-      specifier: 1.47.13
-      version: 1.47.13
+      specifier: 1.47.14
+      version: 1.47.14
     '@milaboratories/strings':
       specifier: 0.1.2
       version: 0.1.2
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.8.3
-      version: 2.8.3
+      specifier: 2.10.0
+      version: 2.10.0
     '@platforma-sdk/blocks-deps-updater':
       specifier: 2.2.0
       version: 2.2.0
@@ -46,20 +46,20 @@ catalogs:
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.77.4
-      version: 1.77.4
+      specifier: 1.77.17
+      version: 1.77.17
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 3.0.3
-      version: 3.0.3
+      specifier: 4.0.0
+      version: 4.0.0
     '@platforma-sdk/ui-vue':
-      specifier: 1.77.4
-      version: 1.77.4
+      specifier: 1.77.17
+      version: 1.77.17
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.26.0
-      version: 5.26.0
+      specifier: 6.1.0
+      version: 6.1.0
     eslint:
       specifier: ^9.25.1
       version: 9.27.0
@@ -88,7 +88,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.3
+        version: 2.10.0
       '@platforma-sdk/blocks-deps-updater':
         specifier: 'catalog:'
         version: 2.2.0
@@ -113,19 +113,19 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.3
+        version: 2.10.0
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.4(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)(@platforma-sdk/ui-vue@1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.77.4
+        version: 1.77.17
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -135,7 +135,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.8.3
+        version: 2.10.0
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.27.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.27.0)(typescript@5.6.3))(eslint-plugin-n@17.18.0(eslint@9.27.0))(eslint-plugin-vue@9.33.0(eslint@9.27.0))(eslint@9.27.0)(globals@15.15.0)(typescript-eslint@8.32.1(eslint@9.27.0)(typescript@5.6.3))(typescript@5.6.3)
@@ -237,10 +237,10 @@ importers:
         version: 3.2.1
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.4(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)(@platforma-sdk/ui-vue@1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.14(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)(@platforma-sdk/ui-vue@1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -249,10 +249,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.77.4
+        version: 1.77.17
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       sass-embedded:
         specifier: 'catalog:'
         version: 1.89.0
@@ -316,11 +316,11 @@ importers:
         version: 1.18.3
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.26.0
+        version: 6.1.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 3.0.3
+        version: 4.0.0
 
 packages:
 
@@ -994,8 +994,8 @@ packages:
   '@milaboratories/biowasm-tools@2.0.2':
     resolution: {integrity: sha512-pe9bIiLni1vMr3tbM87bC2bYRYtwJWeHoZEGAN8WHLRvXW2ouNPvQT5b7LgSsnVtDXsU4L1Eu5cA4W/E94/5tA==}
 
-  '@milaboratories/graph-maker@1.4.3':
-    resolution: {integrity: sha512-67FjRlIolHpMLQYKgvHxjmZXe9bijVvM0vyfgrzwvXW51FxtREpiRjwBJWbmnAALw++vcrLVhuN+lAyhVpSQfw==}
+  '@milaboratories/graph-maker@1.4.4':
+    resolution: {integrity: sha512-vIPpTSVacHsTAAA6LpGAdSoiLZzXd3FZBXdSx8kxSRj7pvsIBif7y4eza/OueP8Dj5hJpvf04bfHnrHHtNCeBQ==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
@@ -1004,11 +1004,11 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
-  '@milaboratories/miplots4@1.2.1':
-    resolution: {integrity: sha512-W9a9bVbW/zsHWSVadhK1ZETdXLdfhrzdPaig9Mr/6Nl9Hn0oHEX94D6pXCgGyfGV5zi7h/rY1pB0l7YUmsP3uA==}
+  '@milaboratories/miplots4@1.2.2':
+    resolution: {integrity: sha512-VMdMxfD/lwObssvYDFRnBcBAV4JFqI2FsoQqmJ/wurIHieoZLU9K0UO57MvsvtmO3Deb9swUjuDUJ+jAe8isqw==}
 
-  '@milaboratories/multi-sequence-alignment@1.47.13':
-    resolution: {integrity: sha512-71PbFOil/+uPOurkkMtj/+9pYMLfx8o79bBgXCw0b98OYBTMseGXYw94vFemPqsFnZX2mVk6kwm/1oz41gZhxg==}
+  '@milaboratories/multi-sequence-alignment@1.47.14':
+    resolution: {integrity: sha512-0GWYp+NrK6Z/S8VogZyInLuSjsPhLNApnSnu1WvXpkBm5r4n5czmPXsPwnzcQauoZxD+TTtFmfiWJY7+e/2AGA==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
@@ -1019,21 +1019,21 @@ packages:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.3.17':
-    resolution: {integrity: sha512-ShmOxNr8ocgZJiOaSC1bD23L1+oqwiaPS5Hh8Bqa9FO1FP7DWPMWV0LtVuUr7ZRGLzivjh9ccQbMyK9QuP5pbg==}
+  '@milaboratories/pf-spec-driver@1.3.22':
+    resolution: {integrity: sha512-+9D8Yf67wbdTy3VTHKL0AlS+SQ/upQoM51TTuTjVZHmFLHA3NTNq5YqGD9mJZcarUa8aYGV8gPnWMtzrqzymsA==}
 
-  '@milaboratories/pframes-rs-wasip2@1.1.35':
-    resolution: {integrity: sha512-kcR9YLWAbKYSpksPOoJWkcrkSiUUAEKj/Wuyc9aFsd2bNbWcIb7mLGptFOuvhLn07bZHn0oNcVgupEqd/6Ftbw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.37':
+    resolution: {integrity: sha512-jR4ZjhGcMPTTZBHjiryed+wgI8tS6+rjS8sAfmxHeFOW5cKTrjnYMIOaUP0PTKs8f2OcM0C/qa4kFo1Hsea29Q==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.35':
-    resolution: {integrity: sha512-wmnEujKa47y+CguYFbeYPjzYAsdhOQO/oNKIyCl0cG/RDwi3qtioKj6DMIBQgjC+/yLPuMsPkjXh7aaPn9cvpA==}
+  '@milaboratories/pframes-rs-wasm@1.1.37':
+    resolution: {integrity: sha512-1U/c2eqz6iVdqqlmK3kG6FuAjbDINFJm7AMK1hwY4l31MXZx8GLnvuYIh1w45yqCW91M6esHxBLR8S/xsqE9ww==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       '@milaboratories/pl-model-common': 1.36.0
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@3.9.0':
-    resolution: {integrity: sha512-YTVLhS9ZhxQAnPOgChNM23TyzlfNd8WiAHnL9TccbBUMUmHsGhLyH3Ys6bOnGdlO9UKWZFQ+co96m2B9WZxjxw==}
+  '@milaboratories/pl-client@3.10.0':
+    resolution: {integrity: sha512-drS1/VDXMqxy5X9y4s6hDIXK0Pa1oEEz1OooEqXFtAf7rXcD3bh74BdzASrOTaeURqQ4ClK5ycJguAnrZ4ef+w==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-error-like@1.12.10':
@@ -1042,14 +1042,14 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-model-backend@1.3.3':
-    resolution: {integrity: sha512-lXOLgKjgteuDnOgf3CMrT13TdD4z36CC8Lail1nvlHKF+ZDbd+nNvsCbIQ5UA/AUVQCd3ucGOacgX2soc/+TyQ==}
+  '@milaboratories/pl-model-backend@1.4.0':
+    resolution: {integrity: sha512-pKhOhn3TkQv5HhGoFsaTzQOvDodIt6NeMb+KzSro/0Edsq/uMrnOG7MbeAkLz5JqWrIAWfBQJgIPUwtl1HmjsQ==}
 
   '@milaboratories/pl-model-common@1.42.0':
     resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.20.0':
-    resolution: {integrity: sha512-RGEJD0avNEBejl1SjCqn7RWNiK15xCNWMXfNziiHUcG4n+QxYm1sk5AezfWsKE3j3y1HdzZnYaoGto9Z1RoV7A==}
+  '@milaboratories/pl-model-middle-layer@1.25.0':
+    resolution: {integrity: sha512-GSa9L86QWHKnk7+mFf8RUyajOtL+DHqxI+QrprVsh6DXAuECiXuSJW7oS2r1I8TE1eESoDINPWyDaBTpmYuQYA==}
 
   '@milaboratories/ptabler-expression-js@1.2.25':
     resolution: {integrity: sha512-dFx+gNoDssA7dQZTr0y93TWuNwlyNY9tzvUaeH0F7BYu/03ZzyLZ4N2iM7ai44bisqAe9o0ppmNM9LtoeTn5Gg==}
@@ -1082,8 +1082,8 @@ packages:
     resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.11':
-    resolution: {integrity: sha512-6I20gxijl8AKIZFWDItWs6cut+v3G0sN3uOhUVTrRW8V77B+f/8e8+HKs+b9F/r5QQ0xP6nJN2nuO+a/EblZcw==}
+  '@milaboratories/uikit@2.14.16':
+    resolution: {integrity: sha512-W7RURPPQh6+7NaJu/uf2MGnh0Eu/Omk2cP9qPH1HHukDTHXsyfJRPbJTO/8JFwiiWf3shQcuDaCm/y06KpJ/Hw==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1370,8 +1370,8 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.9':
     resolution: {integrity: sha512-DtCxrXCaDzjRzEPhlbnJnLfTQatHnGau72D/b8nUtxIgGTNZXG9S3WfRS+VgtaITETbh1x78k4/Qi1o5hUPQHQ==}
 
-  '@platforma-open/milaboratories.software-ptabler@1.16.1':
-    resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
+  '@platforma-open/milaboratories.software-ptabler@2.0.0':
+    resolution: {integrity: sha512-S5PpOkbxFGjbZqM5M0lNPDo0b3wuqHoMbIzvU1duhbDzcDBpgiGE8jdD2e86TFSfS2gHsWCphPAu9QLclLUqxA==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1394,8 +1394,8 @@ packages:
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3':
     resolution: {integrity: sha512-npV+3LXmQNaX5/QsqtsRr5i0oLG7Uu5p51pI27WA2AbN2iyEUbHwbELhEwU26rkdzKTukCvCzs3NTuxIxQy7vQ==}
 
-  '@platforma-sdk/block-tools@2.8.3':
-    resolution: {integrity: sha512-0wAjpHoW6MCecgEh9PinE9lSAjcYBEJgQx1qWTBpPXZKqtLrZy27pamEHQY+mlV/OMa72HDZMy+1eeY53FMQpg==}
+  '@platforma-sdk/block-tools@2.10.0':
+    resolution: {integrity: sha512-TeRyxKuy4e58ZhZnGZ15DorEnABe8xse8+dCS8nBHTa/Ng49os9R8Eeqe8buOci5hZ28h6f2h2vb9+jQmvhw0Q==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1414,23 +1414,23 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.77.4':
-    resolution: {integrity: sha512-YJ/IsURqdaNnOf9JNw8dfmwaZQz1JhEqqR76jK7tmEH7y5ZOKB8mc5Hp3A/x7Wp/9JcXLAVY84h8s6R86FPl4w==}
+  '@platforma-sdk/model@1.77.17':
+    resolution: {integrity: sha512-onPQsX/SZv0sX45Z9CGzW4Eug+EINHcWoEzR3KrDR3fkNv9rJ1EtO+/kbBCpKwjAxAsBzVQoIzGmQAc/bO/AHQ==}
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@3.0.3':
-    resolution: {integrity: sha512-I0zv1iy0UaiShkMGXBZIyB3DnhI6qo8GE9oDzdj0Eql+tESLOGr4iD30UFddW2b68AR6zpsqdREa9OxfGuKgxQ==}
+  '@platforma-sdk/tengo-builder@4.0.0':
+    resolution: {integrity: sha512-k59Hum1a22PzclFUk2H6EZJ6tHPkgjWoGu8dSAGYtl1a2tmw1h4GpeYE/Usrp3hi/0v4zKUyV24VfJ6TSuO1gQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/ui-vue@1.77.4':
-    resolution: {integrity: sha512-7P0+OGqu/BMhuvSqeEi/aBrrA9yCGPhs6jmcJlnP/rqCtwz2+M/CTvaYji7zI5U1htpiN877DdfKezdWUj43oA==}
+  '@platforma-sdk/ui-vue@1.77.17':
+    resolution: {integrity: sha512-HF9jXxWM/yjeaxBF/DQaIvHszTQbKFOR+vHAcYCPJpqjJD8qy8Rg0+PYUhQ8Ddbg0jpQKXedYBTAHf9LBCkr+Q==}
 
-  '@platforma-sdk/workflow-tengo@5.26.0':
-    resolution: {integrity: sha512-lXoFzD0LsQqEF9WUkA48avAY7LOK9WdP7sIc/Bymu1fOm4peXEWWZFW7fYckCPhHEAwcyzjqh7jdE8pVXrfzvw==}
+  '@platforma-sdk/workflow-tengo@6.1.0':
+    resolution: {integrity: sha512-Dw8BvEkph1uhOBcR78WN1jZyUgAVlph7r1Cx0btX+mZVtdxigyURD9ZH6YneCUuIDEdgmLosJMMeblszdlY5oQ==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -6847,14 +6847,14 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.2': {}
 
-  '@milaboratories/graph-maker@1.4.3(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.4(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)(@platforma-sdk/ui-vue@1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
-      '@platforma-sdk/model': 1.77.4
-      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)
+      '@platforma-sdk/model': 1.77.17
+      '@platforma-sdk/ui-vue': 1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.24(typescript@5.6.3))
@@ -6873,7 +6873,7 @@ snapshots:
 
   '@milaboratories/helpers@1.14.2': {}
 
-  '@milaboratories/miplots4@1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
+  '@milaboratories/miplots4@1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
       '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
       '@d3fc/d3fc-pointer': 3.0.3(d3-dispatch@3.0.1)(d3-selection@3.0.0)
@@ -6911,13 +6911,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.13(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)(@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.14(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)(@platforma-sdk/ui-vue@1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.2
-      '@milaboratories/miplots4': 1.2.1(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)
-      '@platforma-sdk/model': 1.77.4
-      '@platforma-sdk/ui-vue': 1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
+      '@milaboratories/pf-plots': 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)
+      '@platforma-sdk/model': 1.77.17
+      '@platforma-sdk/ui-vue': 1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.24(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -6927,34 +6927,34 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.4)':
+  '@milaboratories/pf-plots@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.17)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
-      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/model': 1.77.17
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.3.22(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pframes-rs-wasm': 1.1.37(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.25.0)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.25.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-wasip2@1.1.35': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.37': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.20.0)':
+  '@milaboratories/pframes-rs-wasm@1.1.37(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.25.0)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.35
+      '@milaboratories/pframes-rs-wasip2': 1.1.37
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.25.0
 
-  '@milaboratories/pl-client@3.9.0':
+  '@milaboratories/pl-client@3.10.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
@@ -6981,9 +6981,9 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-model-backend@1.3.3':
+  '@milaboratories/pl-model-backend@1.4.0':
     dependencies:
-      '@milaboratories/pl-client': 3.9.0
+      '@milaboratories/pl-client': 3.10.0
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -6994,7 +6994,7 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.20.0':
+  '@milaboratories/pl-model-middle-layer@1.25.0':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.42.0
@@ -7024,7 +7024,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -7068,10 +7068,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.11(typescript@5.6.3)':
+  '@milaboratories/uikit@2.14.16(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.77.4
+      '@platforma-sdk/model': 1.77.17
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -7287,7 +7287,7 @@ snapshots:
     dependencies:
       '@milaboratories/pl-model-common': 1.42.0
 
-  '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
+  '@platforma-open/milaboratories.software-ptabler@2.0.0': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -7308,13 +7308,13 @@ snapshots:
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3': {}
 
-  '@platforma-sdk/block-tools@2.8.3':
+  '@platforma-sdk/block-tools@2.10.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.3.3
+      '@milaboratories/pl-model-backend': 1.4.0
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.25.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
       '@milaboratories/ts-helpers-oclif': 1.1.41
@@ -7345,12 +7345,12 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.32.1(eslint@9.27.0)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.77.4':
+  '@platforma-sdk/model@1.77.17':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.20.0
+      '@milaboratories/pl-model-middle-layer': 1.25.0
       '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
@@ -7374,21 +7374,21 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@3.0.3':
+  '@platforma-sdk/tengo-builder@4.0.0':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.3.3
+      '@milaboratories/pl-model-backend': 1.4.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.3.0
       winston: 3.17.0
 
-  '@platforma-sdk/ui-vue@1.77.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.77.17(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.3.22(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/uikit': 2.14.11(typescript@5.6.3)
-      '@platforma-sdk/model': 1.77.4
+      '@milaboratories/uikit': 2.14.16(typescript@5.6.3)
+      '@platforma-sdk/model': 1.77.17
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -7419,11 +7419,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.26.0':
+  '@platforma-sdk/workflow-tengo@6.1.0':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.35
+      '@milaboratories/pframes-rs-wasip2': 1.1.37
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 1.16.1
+      '@platforma-open/milaboratories.software-ptabler': 2.0.0
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
       '@platforma-open/milaboratories.software-small-binaries': 2.0.4
 
@@ -11757,7 +11757,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7012,7 +7012,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -11745,7 +11745,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,15 @@ importers:
         specifier: 'catalog:'
         version: 3.12.0
 
+  software/sequence-match:
+    devDependencies:
+      '@platforma-open/milaboratories.runenv-python-3':
+        specifier: 'catalog:'
+        version: 1.7.7
+      '@platforma-sdk/package-builder':
+        specifier: 'catalog:'
+        version: 3.12.0
+
   software/split-fasta:
     devDependencies:
       '@platforma-open/milaboratories.runenv-python-3':
@@ -293,6 +302,9 @@ importers:
       '@platforma-open/milaboratories.immune-assay-data.prepare-fasta':
         specifier: workspace:*
         version: link:../software/prepare-fasta
+      '@platforma-open/milaboratories.immune-assay-data.sequence-match':
+        specifier: workspace:*
+        version: link:../software/sequence-match
       '@platforma-open/milaboratories.immune-assay-data.split-fasta':
         specifier: workspace:*
         version: link:../software/split-fasta

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
   - software/check-content-empty
   - software/split-fasta
   - software/merge-results
+  - software/sequence-match
   - workflow
   - model
   - ui

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,17 +18,17 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.5.0
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 5.26.0
-  '@platforma-sdk/model': 1.77.4
-  '@platforma-sdk/ui-vue': 1.77.4
-  '@platforma-sdk/tengo-builder': 3.0.3
+  '@platforma-sdk/workflow-tengo': 6.1.0
+  '@platforma-sdk/model': 1.77.17
+  '@platforma-sdk/ui-vue': 1.77.17
+  '@platforma-sdk/tengo-builder': 4.0.0
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.8.3
+  '@platforma-sdk/block-tools': 2.10.0
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.77.9
+  '@platforma-sdk/test': 1.77.17
   '@milaboratories/helpers': 1.14.2
-  '@milaboratories/graph-maker': 1.4.3
-  '@milaboratories/multi-sequence-alignment': 1.47.13
+  '@milaboratories/graph-maker': 1.4.4
+  '@milaboratories/multi-sequence-alignment': 1.47.14
   '@milaboratories/strings': 0.1.2
   "@platforma-sdk/blocks-deps-updater": 2.2.0
 

--- a/software/sequence-match/package.json
+++ b/software/sequence-match/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@platforma-open/milaboratories.immune-assay-data.sequence-match",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "pl-pkg build",
+    "prepublishOnly": "pl-pkg prepublish",
+    "do-pack": "rm -f *.tgz && pl-pkg build && pnpm pack && mv platforma-open*.tgz package.tgz",
+    "changeset": "changeset",
+    "version-packages": "changeset version"
+  },
+  "files": [
+    "./dist/**/*"
+  ],
+  "dependencies": {},
+  "devDependencies": {
+    "@platforma-sdk/package-builder": "catalog:",
+    "@platforma-open/milaboratories.runenv-python-3": "catalog:"
+  },
+  "block-software": {
+    "entrypoints": {
+      "main": {
+        "binary": {
+          "artifact": {
+            "type": "python",
+            "registry": "platforma-open",
+            "environment": "@platforma-open/milaboratories.runenv-python-3:3.12.10",
+            "dependencies": {
+              "toolset": "pip",
+              "requirements": "requirements.txt"
+            },
+            "root": "./src"
+          },
+          "cmd": [
+            "python",
+            "{pkg}/main.py"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/software/sequence-match/src/main.py
+++ b/software/sequence-match/src/main.py
@@ -1,0 +1,99 @@
+"""Recall-guaranteed sequence matching for immune-assay-data.
+
+Reports every clone whose sequence contains an assay sequence as an exact
+substring (containment). This is the deterministic, recall-guaranteed equivalent
+of an MMseqs2 id=1 / cov=1 search: an assay peptide that occurs verbatim inside a
+(longer) clone sequence is reported, and nothing within the configured criterion
+is ever silently missed.
+
+Matching uses polars' built-in Aho-Corasick multi-pattern scan (`str.extract_many`):
+the automaton is built once over all assay sequences and each clone is scanned a
+single time, so cost is O(total clone length), independent of the assay-set size.
+
+Output is a BLAST-tab TSV with the same columns the MMseqs2 path emits, so the
+downstream post-processing in `analysis.tpl.tengo` is unchanged. The alignment
+statistics are synthesized for an exact substring hit: 100% identity, no
+mismatches/gaps, query fully covered. Coordinates use placeholder spans (the
+in-clone offset is not reported in this version).
+"""
+import argparse
+
+import polars as pl
+
+# Canonical BLAST-tab columns the downstream post-processing reads (by name).
+HEADER = [
+    "query", "target", "pident", "alnlen", "mismatch", "gapopen",
+    "qstart", "qend", "tstart", "tend", "evalue", "bits",
+]
+
+
+def write_empty(path: str) -> None:
+    """Header-only output — matches the MMseqs2 path's empty-result shape."""
+    pl.DataFrame({c: [] for c in HEADER}).write_csv(path, separator="\t")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--clones", required=True, help="Clones TSV with seqId, sequence.")
+    ap.add_argument("--assay", required=True, help="Assay TSV with seqId, sequence.")
+    ap.add_argument("--output", required=True, help="Output BLAST-tab TSV (with header).")
+    args = ap.parse_args()
+
+    # Upper-case both sides so matching is case-insensitive; the matched text then
+    # equals the (upper-cased) assay needle, which keeps the join below exact.
+    clones = pl.read_csv(args.clones, separator="\t").select(
+        pl.col("seqId").cast(pl.Utf8).alias("target"),
+        pl.col("sequence").cast(pl.Utf8).str.to_uppercase().alias("cseq"),
+    )
+    assay = pl.read_csv(args.assay, separator="\t").select(
+        pl.col("seqId").cast(pl.Utf8).alias("query"),
+        pl.col("sequence").cast(pl.Utf8).str.to_uppercase().alias("qseq"),
+    ).unique(subset="qseq")
+
+    needles = assay["qseq"].to_list()
+    if not needles or clones.height == 0:
+        write_empty(args.output)
+        return
+
+    # Aho-Corasick: which assay needles each clone contains. overlapping=True is
+    # required for recall — every occurrence is reported, even overlapping ones.
+    hits = (
+        clones.with_columns(
+            pl.col("cseq").str.extract_many(needles, overlapping=True).alias("qseq"),
+        )
+        .explode("qseq")
+        .drop_nulls("qseq")
+        .select("target", "qseq")
+        .unique()  # one row per (clone, assay needle)
+    )
+
+    if hits.height == 0:
+        write_empty(args.output)
+        return
+
+    res = (
+        hits.join(assay, on="qseq", how="inner")  # attach the assay query id
+        .with_columns(pl.col("qseq").str.len_chars().cast(pl.Int64).alias("alnlen"))
+        .with_columns(
+            pl.lit(100.0).alias("pident"),
+            pl.lit(0, dtype=pl.Int64).alias("mismatch"),
+            pl.lit(0, dtype=pl.Int64).alias("gapopen"),
+            pl.lit(1, dtype=pl.Int64).alias("qstart"),
+            pl.col("alnlen").alias("qend"),
+            pl.lit(1, dtype=pl.Int64).alias("tstart"),
+            pl.col("alnlen").alias("tend"),
+            pl.lit(0.0).alias("evalue"),
+            pl.col("alnlen").cast(pl.Float64).alias("bits"),
+        )
+        .select(HEADER)
+        .sort(["target", "query"])  # deterministic, canonical output
+    )
+    res.write_csv(args.output, separator="\t")
+    print(
+        f"Sequence match (containment): {res.height} matches, "
+        f"{res['target'].n_unique()} clonotypes, {res['query'].n_unique()} assay sequences.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/software/sequence-match/src/requirements.txt
+++ b/software/sequence-match/src/requirements.txt
@@ -1,0 +1,1 @@
+polars-lts-cpu==1.33.1

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -388,7 +388,7 @@ const similarityTypeOptions = [
       >
         <template #tooltip>
           Alignment runs MMseqs2 (BLOSUM or identity scoring, with identity and coverage thresholds).
-          Sequence Match reports only identical sequences — no alignment, available only when the assay and target use the same alphabet.
+          Sequence Match reports targets that contain an assay sequence exactly (substring match) — no alignment, guaranteed recall, available only when the assay and target use the same alphabet.
         </template>
       </PlBtnGroup>
 

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -248,10 +248,24 @@ const otherColumnOptions = computed(() => {
     }));
 });
 
-const similarityTypeOptions = [
-  { label: 'BLOSUM', value: 'alignment-score' },
-  { label: 'Exact Match', value: 'sequence-identity' },
-];
+// Matching method options. The exact-equality option ("Identical sequences")
+// is gated: exact string matching cannot work across alphabets (MMseqs2 does
+// that via translated search). Hide it only when we know the assay and target
+// alphabets differ — the workflow asserts as the hard backstop.
+const similarityTypeOptions = computed(() => {
+  const opts = [
+    { label: 'BLOSUM', value: 'alignment-score' },
+    { label: 'Exact Match', value: 'sequence-identity' },
+  ];
+  const assayAlphabet = app.model.data.importColumns
+    ?.find((c) => c.header === app.model.data.sequenceColumnHeader)?.sequenceType;
+  const targetAlphabet = app.model.outputs.targetSequenceType;
+  const knownAndDiffer = !!assayAlphabet && !!targetAlphabet && assayAlphabet !== targetAlphabet;
+  if (!knownAndDiffer) {
+    opts.push({ label: 'Identical sequences', value: 'exact-match' });
+  }
+  return opts;
+});
 </script>
 
 <template>
@@ -346,12 +360,15 @@ const similarityTypeOptions = [
         label="Alignment Score"
       >
         <template #tooltip>
-          Select the similarity metric used for matching thresholds. BLOSUM considers biochemical similarity while Exact
-          Match counts only identical residues.
+          Select how assay and target sequences are matched. BLOSUM considers biochemical similarity;
+          Exact Match counts only identical residues — both run alignment (MMseqs2) and may miss some
+          matches on difficult sequences. Identical sequences reports only byte-identical sequences with
+          no alignment and guaranteed recall (same alphabet only).
         </template>
       </PlDropdown>
 
       <PlNumberField
+        v-if="app.model.data.settings.similarityType !== 'exact-match'"
         v-model="app.model.data.settings.identity"
         label="Score threshold" :min-value="0.1" :step="0.1" :max-value="1.0"
       >
@@ -361,6 +378,7 @@ const similarityTypeOptions = [
       </PlNumberField>
 
       <PlNumberField
+        v-if="app.model.data.settings.similarityType !== 'exact-match'"
         v-model="app.model.data.settings.coverageThreshold"
         label="Coverage threshold"
         :min-value="0.1"
@@ -374,7 +392,10 @@ const similarityTypeOptions = [
       </PlNumberField>
 
       <PlAccordionSection :label="strings.titles.advancedSettings">
-        <PlCheckbox v-model="app.model.data.lessSensitive">
+        <PlCheckbox
+          v-if="app.model.data.settings.similarityType !== 'exact-match'"
+          v-model="app.model.data.lessSensitive"
+        >
           Fast mode
           <PlTooltip class="info" position="top">
             <template #tooltip>Prioritizes speed over sensitivity. Reduces prefiltering precision, which may miss some weaker matches but significantly speeds up alignment for large datasets.</template>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -20,6 +20,7 @@ import {
   PlAlert,
   PlBlockPage,
   PlBtnGhost,
+  PlBtnGroup,
   PlCheckbox,
   PlDropdown,
   PlDropdownMulti,
@@ -248,24 +249,48 @@ const otherColumnOptions = computed(() => {
     }));
 });
 
-// Matching method options. The exact-equality option ("Identical sequences")
-// is gated: exact string matching cannot work across alphabets (MMseqs2 does
-// that via translated search). Hide it only when we know the assay and target
-// alphabets differ — the workflow asserts as the hard backstop.
-const similarityTypeOptions = computed(() => {
-  const opts = [
-    { label: 'BLOSUM', value: 'alignment-score' },
-    { label: 'Exact Match', value: 'sequence-identity' },
-  ];
+// Top-level matching approach: Alignment (MMseqs2) vs Sequence Match (exact,
+// byte-identical, recall-guaranteed). Derived from settings.similarityType —
+// 'exact-match' is Sequence Match; the other two are Alignment sub-modes.
+const matchingApproach = computed(() =>
+  app.model.data.settings.similarityType === 'exact-match' ? 'sequence-match' : 'alignment',
+);
+
+// Remember the last Alignment sub-mode so toggling back from Sequence Match
+// restores the user's choice instead of always resetting to BLOSUM.
+const lastAlignmentType = ref<'alignment-score' | 'sequence-identity'>(
+  app.model.data.settings.similarityType === 'sequence-identity' ? 'sequence-identity' : 'alignment-score',
+);
+watch(
+  () => app.model.data.settings.similarityType,
+  (t) => {
+    if (t === 'alignment-score' || t === 'sequence-identity') lastAlignmentType.value = t;
+  },
+);
+
+function setMatchingApproach(value: string) {
+  app.model.data.settings.similarityType
+    = value === 'sequence-match' ? 'exact-match' : lastAlignmentType.value;
+}
+
+// Sequence Match is gated: exact equality can't match across alphabets (MMseqs2
+// handles that via translated search). Hide the option only when we know the
+// assay and target alphabets differ; the workflow asserts as the hard backstop.
+const matchingApproachOptions = computed(() => {
+  const opts = [{ label: 'Alignment', value: 'alignment' }];
   const assayAlphabet = app.model.data.importColumns
     ?.find((c) => c.header === app.model.data.sequenceColumnHeader)?.sequenceType;
   const targetAlphabet = app.model.outputs.targetSequenceType;
   const knownAndDiffer = !!assayAlphabet && !!targetAlphabet && assayAlphabet !== targetAlphabet;
-  if (!knownAndDiffer) {
-    opts.push({ label: 'Identical sequences', value: 'exact-match' });
-  }
+  if (!knownAndDiffer) opts.push({ label: 'Sequence Match', value: 'sequence-match' });
   return opts;
 });
+
+// Alignment sub-modes (MMseqs2 scoring).
+const similarityTypeOptions = [
+  { label: 'BLOSUM', value: 'alignment-score' },
+  { label: 'Exact Match', value: 'sequence-identity' },
+];
 </script>
 
 <template>
@@ -355,45 +380,54 @@ const similarityTypeOptions = computed(() => {
       />
 
       <PlSectionSeparator>Matching parameters</PlSectionSeparator>
-      <PlDropdown
-        v-model="app.model.data.settings.similarityType" :options="similarityTypeOptions"
-        label="Alignment Score"
+      <PlBtnGroup
+        :model-value="matchingApproach"
+        :options="matchingApproachOptions"
+        label="Matching mode"
+        @update:model-value="setMatchingApproach"
       >
         <template #tooltip>
-          Select how assay and target sequences are matched. BLOSUM considers biochemical similarity;
-          Exact Match counts only identical residues — both run alignment (MMseqs2) and may miss some
-          matches on difficult sequences. Identical sequences reports only byte-identical sequences with
-          no alignment and guaranteed recall (same alphabet only).
+          Alignment runs MMseqs2 (BLOSUM or identity scoring, with identity and coverage thresholds).
+          Sequence Match reports only identical sequences — no alignment, available only when the assay and target use the same alphabet.
         </template>
-      </PlDropdown>
+      </PlBtnGroup>
 
-      <PlNumberField
-        v-if="app.model.data.settings.similarityType !== 'exact-match'"
-        v-model="app.model.data.settings.identity"
-        label="Score threshold" :min-value="0.1" :step="0.1" :max-value="1.0"
-      >
-        <template #tooltip>
-          Sets the lowest percentage of identical residues required for a match.
-        </template>
-      </PlNumberField>
+      <template v-if="matchingApproach === 'alignment'">
+        <PlDropdown
+          v-model="app.model.data.settings.similarityType" :options="similarityTypeOptions"
+          label="Alignment Score"
+        >
+          <template #tooltip>
+            BLOSUM considers biochemical similarity; Exact Match counts only identical residues.
+          </template>
+        </PlDropdown>
 
-      <PlNumberField
-        v-if="app.model.data.settings.similarityType !== 'exact-match'"
-        v-model="app.model.data.settings.coverageThreshold"
-        label="Coverage threshold"
-        :min-value="0.1"
-        :step="0.1"
-        :max-value="1.0"
-      >
-        <template #tooltip>
-          Minimum fraction of residues that must align between the input sequence and the assay
-          sequence to count as a match.
-        </template>
-      </PlNumberField>
+        <PlNumberField
+          v-model="app.model.data.settings.identity"
+          label="Score threshold" :min-value="0.1" :step="0.1" :max-value="1.0"
+        >
+          <template #tooltip>
+            Sets the lowest percentage of identical residues required for a match.
+          </template>
+        </PlNumberField>
+
+        <PlNumberField
+          v-model="app.model.data.settings.coverageThreshold"
+          label="Coverage threshold"
+          :min-value="0.1"
+          :step="0.1"
+          :max-value="1.0"
+        >
+          <template #tooltip>
+            Minimum fraction of residues that must align between the input sequence and the assay
+            sequence to count as a match.
+          </template>
+        </PlNumberField>
+      </template>
 
       <PlAccordionSection :label="strings.titles.advancedSettings">
         <PlCheckbox
-          v-if="app.model.data.settings.similarityType !== 'exact-match'"
+          v-if="matchingApproach === 'alignment'"
           v-model="app.model.data.lessSensitive"
         >
           Fast mode

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -18,6 +18,7 @@
     "@platforma-open/milaboratories.immune-assay-data.check-content-empty": "workspace:*",
     "@platforma-open/milaboratories.immune-assay-data.split-fasta": "workspace:*",
     "@platforma-open/milaboratories.immune-assay-data.merge-results": "workspace:*",
+    "@platforma-open/milaboratories.immune-assay-data.sequence-match": "workspace:*",
     "@platforma-open/soedinglab.software-mmseqs2": "catalog:"
   },
   "devDependencies": {

--- a/workflow/src/analysis.tpl.tengo
+++ b/workflow/src/analysis.tpl.tengo
@@ -14,6 +14,7 @@ xlsxToCsvSw := assets.importSoftware("@platforma-open/milaboratories.immune-assa
 checkContentEmptySw := assets.importSoftware("@platforma-open/milaboratories.immune-assay-data.check-content-empty:main")
 splitFastaSw := assets.importSoftware("@platforma-open/milaboratories.immune-assay-data.split-fasta:main")
 mergeResultsSw := assets.importSoftware("@platforma-open/milaboratories.immune-assay-data.merge-results:main")
+sequenceMatchSw := assets.importSoftware("@platforma-open/milaboratories.immune-assay-data.sequence-match:main")
 
 runAlignmentTpl := assets.importTemplate(":run-alignment")
 checkContentEmptyTpl := assets.importTemplate(":check-content-empty")
@@ -135,69 +136,37 @@ prepareAssayFile := func(file, xsvType, sequenceColumnHeader) {
 }
 
 /**
- * Exact-match ("Identical sequences") path. Reports only byte-identical
- * sequences between assay and clones — no alignment, recall guaranteed.
+ * Sequence Match (containment) path. Reports every clone whose sequence contains
+ * an assay sequence as an exact substring — the recall-guaranteed equivalent of
+ * an MMseqs2 id=1 / cov=1 search, with no alignment heuristics and no silent
+ * misses. Matching runs in a Python software package via polars' built-in
+ * Aho-Corasick scan (O(total clone length), independent of assay-set size).
  * Emits a BLAST-tab TSV with the same columns the MMseqs2 path produces, so the
- * downstream post-processing runs unchanged. Sequences are upper-cased on both
- * sides before equality so case differences in user assay files still match.
- * The join is a hash equi-join (O(N+M)) — no k-mer index, no chunking.
+ * downstream post-processing runs unchanged.
  */
-runExactMatch := func(assayTsv, clonesTsv, mem, cpu) {
-	ptw := pt.workflow()
-	ptMem := "16GiB"
+runSequenceMatch := func(assayTsv, clonesTsv, mem, cpu) {
+	matchMem := "16GiB"
 	if !is_undefined(mem) {
-		ptMem = string(mem) + "GiB"
+		matchMem = string(mem) + "GiB"
 	}
-	ptw.mem(ptMem)
+	matchCpu := 1
 	if !is_undefined(cpu) {
-		ptw.cpu(cpu)
+		matchCpu = cpu
 	}
 
-	// Assay side: seqId -> query, normalized sequence, and alignment length.
-	assayDf := ptw.frame({ file: assayTsv, xsvType: "tsv" }).
-		select(
-			pt.col("seqId").alias("query"),
-			pt.col("sequence").strToUpper().alias("assaySeq"),
-			pt.col("sequence").strLenChars().cast("Int64").alias("alnlen")
-		)
+	e := exec.builder().
+		software(sequenceMatchSw).
+		mem(matchMem).
+		cpu(matchCpu).
+		addFile("clones.tsv", clonesTsv).
+		addFile("assay.tsv", assayTsv).
+		arg("--clones").arg("clones.tsv").
+		arg("--assay").arg("assay.tsv").
+		arg("--output").arg("results_with_header.tsv").
+		saveFile("results_with_header.tsv").
+		run()
 
-	// Clones side: seqId -> target, normalized sequence.
-	clonesDf := ptw.frame({ file: clonesTsv, xsvType: "tsv" }).
-		select(
-			pt.col("seqId").alias("target"),
-			pt.col("sequence").strToUpper().alias("cloneSeq")
-		)
-
-	// Inner join on exact (normalized) sequence equality.
-	joined := assayDf.join(clonesDf, {
-		how: "inner",
-		leftOn: "assaySeq",
-		rightOn: "cloneSeq"
-	})
-
-	// Fabricate the BLAST-tab columns the downstream expects. Exact match has no
-	// alignment: 100% identity, full span, zero mismatches/gaps, best e-value.
-	// bits = alnlen keeps the downstream max-bits tiebreak well-defined.
-	joined = joined.withColumns(
-		pt.lit(100.0).cast("Float64").alias("pident"),
-		pt.lit(0).cast("Int64").alias("mismatch"),
-		pt.lit(0).cast("Int64").alias("gapopen"),
-		pt.lit(1).cast("Int64").alias("qstart"),
-		pt.lit(1).cast("Int64").alias("tstart"),
-		pt.lit(0.0).cast("Float64").alias("evalue"),
-		pt.col("alnlen").alias("qend"),
-		pt.col("alnlen").alias("tend"),
-		pt.col("alnlen").cast("Float64").alias("bits")
-	)
-
-	// Deterministic order so the output is canonical for pure-template dedup.
-	joined = joined.select(
-		"target", "query", "evalue", "bits", "pident",
-		"alnlen", "mismatch", "gapopen", "qstart", "qend", "tstart", "tend"
-	).sort(["target", "query"])
-
-	joined.save("results_with_header.tsv")
-	return ptw.run().getFile("results_with_header.tsv")
+	return e.getFile("results_with_header.tsv")
 }
 
 self.defineOutputs(
@@ -285,9 +254,10 @@ self.body(func(args) {
 	// schema, so everything downstream is identical regardless of mode.
 	mmseqsResultTsv := undefined
 	if string(similarityType) == "exact-match" {
-		// Exact ("Identical sequences") mode — recall-guaranteed string equality.
-		// No alignment, no MMseqs2: skip cov-mode calc, clone chunking, and merge.
-		mmseqsResultTsv = runExactMatch(assayTsv, clonesTsv, mem, cpu)
+		// Sequence Match mode — recall-guaranteed exact substring (containment)
+		// matching. No alignment, no MMseqs2: skip cov-mode calc, clone chunking,
+		// and merge; a Python/polars Aho-Corasick step produces the results TSV.
+		mmseqsResultTsv = runSequenceMatch(assayTsv, clonesTsv, mem, cpu)
 	} else {
 		// Prepare assay FASTA (clones FASTA already prepared upstream)
 		assayFastaRun := runTsvToFasta(assayTsv, "seqId", "sequence")

--- a/workflow/src/analysis.tpl.tengo
+++ b/workflow/src/analysis.tpl.tengo
@@ -134,6 +134,72 @@ prepareAssayFile := func(file, xsvType, sequenceColumnHeader) {
     return ptw.run().getFile("output.tsv")
 }
 
+/**
+ * Exact-match ("Identical sequences") path. Reports only byte-identical
+ * sequences between assay and clones — no alignment, recall guaranteed.
+ * Emits a BLAST-tab TSV with the same columns the MMseqs2 path produces, so the
+ * downstream post-processing runs unchanged. Sequences are upper-cased on both
+ * sides before equality so case differences in user assay files still match.
+ * The join is a hash equi-join (O(N+M)) — no k-mer index, no chunking.
+ */
+runExactMatch := func(assayTsv, clonesTsv, mem, cpu) {
+	ptw := pt.workflow()
+	ptMem := "16GiB"
+	if !is_undefined(mem) {
+		ptMem = string(mem) + "GiB"
+	}
+	ptw.mem(ptMem)
+	if !is_undefined(cpu) {
+		ptw.cpu(cpu)
+	}
+
+	// Assay side: seqId -> query, normalized sequence, and alignment length.
+	assayDf := ptw.frame({ file: assayTsv, xsvType: "tsv" }).
+		select(
+			pt.col("seqId").alias("query"),
+			pt.col("sequence").strToUpper().alias("assaySeq"),
+			pt.col("sequence").strLenChars().cast("Int64").alias("alnlen")
+		)
+
+	// Clones side: seqId -> target, normalized sequence.
+	clonesDf := ptw.frame({ file: clonesTsv, xsvType: "tsv" }).
+		select(
+			pt.col("seqId").alias("target"),
+			pt.col("sequence").strToUpper().alias("cloneSeq")
+		)
+
+	// Inner join on exact (normalized) sequence equality.
+	joined := assayDf.join(clonesDf, {
+		how: "inner",
+		leftOn: "assaySeq",
+		rightOn: "cloneSeq"
+	})
+
+	// Fabricate the BLAST-tab columns the downstream expects. Exact match has no
+	// alignment: 100% identity, full span, zero mismatches/gaps, best e-value.
+	// bits = alnlen keeps the downstream max-bits tiebreak well-defined.
+	joined = joined.withColumns(
+		pt.lit(100.0).cast("Float64").alias("pident"),
+		pt.lit(0).cast("Int64").alias("mismatch"),
+		pt.lit(0).cast("Int64").alias("gapopen"),
+		pt.lit(1).cast("Int64").alias("qstart"),
+		pt.lit(1).cast("Int64").alias("tstart"),
+		pt.lit(0.0).cast("Float64").alias("evalue"),
+		pt.col("alnlen").alias("qend"),
+		pt.col("alnlen").alias("tend"),
+		pt.col("alnlen").cast("Float64").alias("bits")
+	)
+
+	// Deterministic order so the output is canonical for pure-template dedup.
+	joined = joined.select(
+		"target", "query", "evalue", "bits", "pident",
+		"alnlen", "mismatch", "gapopen", "qstart", "qend", "tstart", "tend"
+	).sort(["target", "query"])
+
+	joined.save("results_with_header.tsv")
+	return ptw.run().getFile("results_with_header.tsv")
+}
+
 self.defineOutputs(
 	"bestAlignmentTsv",
 	"assayDataTsv",
@@ -149,6 +215,7 @@ self.body(func(args) {
 	xsvType := args.xsvType
 	sequenceColumnHeader := args.sequenceColumnHeader
 	clonesFasta := args.clonesFasta
+	clonesTsv := args.clonesTsv
 	emptyClonesInput := args.emptyClonesInput
 	targetSequenceType := args.targetSequenceType
 	assaySequenceType := args.assaySequenceType
@@ -214,116 +281,125 @@ self.body(func(args) {
 
 	assayTsv := prepareAssayFile(file, xsvType, sequenceColumnHeader)
 
-	// Prepare assay FASTA (clones FASTA already prepared upstream)
-	assayFastaRun := runTsvToFasta(assayTsv, "seqId", "sequence")
-	assayFasta := assayFastaRun.getFile("output.fasta")
+	// Build the raw results TSV (BLAST-tab + header). Two paths produce the same
+	// schema, so everything downstream is identical regardless of mode.
+	mmseqsResultTsv := undefined
+	if string(similarityType) == "exact-match" {
+		// Exact ("Identical sequences") mode — recall-guaranteed string equality.
+		// No alignment, no MMseqs2: skip cov-mode calc, clone chunking, and merge.
+		mmseqsResultTsv = runExactMatch(assayTsv, clonesTsv, mem, cpu)
+	} else {
+		// Prepare assay FASTA (clones FASTA already prepared upstream)
+		assayFastaRun := runTsvToFasta(assayTsv, "seqId", "sequence")
+		assayFasta := assayFastaRun.getFile("output.fasta")
 
-	// Dynamically determine coverage mode by comparing average sequence lengths
-	coverageModeRun := exec.builder().
-		software(covModeCalcSw).
-		mem("16GiB").
-		cpu(1).
-		addFile("clones.fasta", clonesFasta).
-		addFile("assay.fasta", assayFasta).
-		arg("--clones-fasta").arg("clones.fasta").
-		arg("--assay-fasta").arg("assay.fasta").
-		arg("--output").arg("coverage_mode.txt").
-		saveFileContent("coverage_mode.txt").
-		run()
+		// Dynamically determine coverage mode by comparing average sequence lengths
+		coverageModeRun := exec.builder().
+			software(covModeCalcSw).
+			mem("16GiB").
+			cpu(1).
+			addFile("clones.fasta", clonesFasta).
+			addFile("assay.fasta", assayFasta).
+			arg("--clones-fasta").arg("clones.fasta").
+			arg("--assay-fasta").arg("assay.fasta").
+			arg("--output").arg("coverage_mode.txt").
+			saveFileContent("coverage_mode.txt").
+			run()
 
-	covMode := coverageModeRun.getFileContent("coverage_mode.txt")
+		covMode := coverageModeRun.getFileContent("coverage_mode.txt")
 
-	// Split clone FASTA into 2 equal chunks to limit mmseqs2 index disk usage.
-	// Running two searches against 25M sequences each uses half the peak disk
-	// of a single 50M search. E-values are normalized to the full database size.
-	splitRun := exec.builder().
-		software(splitFastaSw).
-		mem("8GiB").
-		cpu(1).
-		addFile("clones.fasta", clonesFasta).
-		arg("-i").arg("clones.fasta").
-		arg("--chunk1").arg("chunk_1.fasta").
-		arg("--chunk2").arg("chunk_2.fasta").
-		arg("--counts").arg("counts.json").
-		saveFile("chunk_1.fasta").
-		saveFile("chunk_2.fasta").
-		saveFile("counts.json").
-		run()
+		// Split clone FASTA into 2 equal chunks to limit mmseqs2 index disk usage.
+		// Running two searches against 25M sequences each uses half the peak disk
+		// of a single 50M search. E-values are normalized to the full database size.
+		splitRun := exec.builder().
+			software(splitFastaSw).
+			mem("8GiB").
+			cpu(1).
+			addFile("clones.fasta", clonesFasta).
+			arg("-i").arg("clones.fasta").
+			arg("--chunk1").arg("chunk_1.fasta").
+			arg("--chunk2").arg("chunk_2.fasta").
+			arg("--counts").arg("counts.json").
+			saveFile("chunk_1.fasta").
+			saveFile("chunk_2.fasta").
+			saveFile("counts.json").
+			run()
 
-	chunk1Fasta := splitRun.getFile("chunk_1.fasta")
-	chunk2Fasta := splitRun.getFile("chunk_2.fasta")
-	splitCounts := splitRun.getFile("counts.json")
+		chunk1Fasta := splitRun.getFile("chunk_1.fasta")
+		chunk2Fasta := splitRun.getFile("chunk_2.fasta")
+		splitCounts := splitRun.getFile("counts.json")
 
-	// MMseqs2 Alignment
-	mmseqsSearchType := "0"
-    if targetSequenceType == "aminoacid" && assaySequenceType == "aminoacid" {
-        //1: amino acid
-        mmseqsSearchType = "1"
-    } else if targetSequenceType == "nucleotide" && assaySequenceType == "nucleotide" {
-        // 3: nucleotide
-        mmseqsSearchType = "3"
-    } else if targetSequenceType == "nucleotide" && assaySequenceType == "aminoacid" {
-        // 4: translated nucleotide alignment
-        mmseqsSearchType = "4"
-    } else if targetSequenceType == "aminoacid" && assaySequenceType == "nucleotide"  {
-        // 2: nucleotide
-        mmseqsSearchType = "2"
-    }
-
-	runMmseqs1 := render.create(runAlignmentTpl, {
-		covMode: covMode,
-		mmseqsSearchType: mmseqsSearchType,
-		coverageThreshold: coverageThreshold,
-		identityThreshold: identityThreshold,
-		similarityType: similarityType,
-		clonesFasta: chunk1Fasta,
-		assayFasta: assayFasta,
-		lessSensitive: lessSensitive,
-		isPeptide: args.isPeptide,
-		minPeptideLength: args.minPeptideLength
-	}, {
-		metaInputs: {
-			mem: mem,
-			cpu: cpu
+		// MMseqs2 Alignment
+		mmseqsSearchType := "0"
+		if targetSequenceType == "aminoacid" && assaySequenceType == "aminoacid" {
+			//1: amino acid
+			mmseqsSearchType = "1"
+		} else if targetSequenceType == "nucleotide" && assaySequenceType == "nucleotide" {
+			// 3: nucleotide
+			mmseqsSearchType = "3"
+		} else if targetSequenceType == "nucleotide" && assaySequenceType == "aminoacid" {
+			// 4: translated nucleotide alignment
+			mmseqsSearchType = "4"
+		} else if targetSequenceType == "aminoacid" && assaySequenceType == "nucleotide"  {
+			// 2: nucleotide
+			mmseqsSearchType = "2"
 		}
-	})
-	runMmseqs2 := render.create(runAlignmentTpl, {
-		covMode: covMode,
-		mmseqsSearchType: mmseqsSearchType,
-		coverageThreshold: coverageThreshold,
-		identityThreshold: identityThreshold,
-		similarityType: similarityType,
-		clonesFasta: chunk2Fasta,
-		assayFasta: assayFasta,
-		lessSensitive: lessSensitive,
-		isPeptide: args.isPeptide,
-		minPeptideLength: args.minPeptideLength
-	}, {
-		metaInputs: {
-			mem: mem,
-			cpu: cpu
-		}
-	})
 
-	mmseqsOutput1 := runMmseqs1.output("mmseqsOutput")
-	mmseqsOutput2 := runMmseqs2.output("mmseqsOutput")
+		runMmseqs1 := render.create(runAlignmentTpl, {
+			covMode: covMode,
+			mmseqsSearchType: mmseqsSearchType,
+			coverageThreshold: coverageThreshold,
+			identityThreshold: identityThreshold,
+			similarityType: similarityType,
+			clonesFasta: chunk1Fasta,
+			assayFasta: assayFasta,
+			lessSensitive: lessSensitive,
+			isPeptide: args.isPeptide,
+			minPeptideLength: args.minPeptideLength
+		}, {
+			metaInputs: {
+				mem: mem,
+				cpu: cpu
+			}
+		})
+		runMmseqs2 := render.create(runAlignmentTpl, {
+			covMode: covMode,
+			mmseqsSearchType: mmseqsSearchType,
+			coverageThreshold: coverageThreshold,
+			identityThreshold: identityThreshold,
+			similarityType: similarityType,
+			clonesFasta: chunk2Fasta,
+			assayFasta: assayFasta,
+			lessSensitive: lessSensitive,
+			isPeptide: args.isPeptide,
+			minPeptideLength: args.minPeptideLength
+		}, {
+			metaInputs: {
+				mem: mem,
+				cpu: cpu
+			}
+		})
 
-	// Merge both raw results, add header, and normalize e-values to full database size
-	mergeRun := exec.builder().
-		software(mergeResultsSw).
-		mem("16GiB").
-		cpu(1).
-		addFile("results_1.tsv", mmseqsOutput1).
-		addFile("results_2.tsv", mmseqsOutput2).
-		addFile("counts.json", splitCounts).
-		arg("-i1").arg("results_1.tsv").
-		arg("-i2").arg("results_2.tsv").
-		arg("--counts").arg("counts.json").
-		arg("-o").arg("results_with_header.tsv").
-		saveFile("results_with_header.tsv").
-		run()
+		mmseqsOutput1 := runMmseqs1.output("mmseqsOutput")
+		mmseqsOutput2 := runMmseqs2.output("mmseqsOutput")
 
-	mmseqsResultTsv := mergeRun.getFile("results_with_header.tsv")
+		// Merge both raw results, add header, and normalize e-values to full database size
+		mergeRun := exec.builder().
+			software(mergeResultsSw).
+			mem("16GiB").
+			cpu(1).
+			addFile("results_1.tsv", mmseqsOutput1).
+			addFile("results_2.tsv", mmseqsOutput2).
+			addFile("counts.json", splitCounts).
+			arg("-i1").arg("results_1.tsv").
+			arg("-i2").arg("results_2.tsv").
+			arg("--counts").arg("counts.json").
+			arg("-o").arg("results_with_header.tsv").
+			saveFile("results_with_header.tsv").
+			run()
+
+		mmseqsResultTsv = mergeRun.getFile("results_with_header.tsv")
+	}
 
 	// Check if results are empty (only header line or nothing)
 	checkResultsRun := exec.builder().

--- a/workflow/src/extract-unique-values.tpl.tengo
+++ b/workflow/src/extract-unique-values.tpl.tengo
@@ -1,6 +1,5 @@
 self := import("@platforma-sdk/workflow-tengo:tpl")
 maps := import("@platforma-sdk/workflow-tengo:maps")
-slices := import("@platforma-sdk/workflow-tengo:slices")
 json := import("json")
 text := import("text")
 
@@ -18,10 +17,13 @@ self.body(func(inputs) {
 		lines := text.split(text.trim_space(content), "\n")
 
 		if len(lines) > 1 {
-			// Skip header and sort values so the JSON-encoded array is
-			// canonical (polars groupBy output order is implementation-
-			// defined; sorting here makes the spec annotation stable).
-			values := slices.quickSortInPlace(lines[1:])
+			// Values arrive already sorted from get-unique-values (polars
+			// `.sort(["value"])`), so the file lines are in canonical order —
+			// skip the header and use them as-is. Do NOT re-sort here: the
+			// recursive quickSort overflows the Tengo VM value stack (size 2048)
+			// on already-sorted input once a column has a few hundred unique
+			// values (O(n) recursion depth).
+			values := lines[1:]
 			// JSON encode the array of strings and convert to string
 			uniqueValuesMap[header] = string(json.encode(values))
 		}

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -109,13 +109,12 @@ wf.body(func(args) {
 		ll.panic("Assay sequence type is undefined")
 	}
 
-	// Backstop for the exact-match (Identical sequences) mode. String equality
-	// cannot match across alphabets — MMseqs2 handles that via translated
-	// search, exact mode does not. The UI gates the option, this guards the
-	// edge case of a persisted exact-match selection over a now-mismatched
-	// target (defence in depth).
+	// Backstop for Sequence Match mode. Substring matching cannot work across
+	// alphabets — MMseqs2 handles that via translated search, Sequence Match does
+	// not. The UI gates the option; this guards the edge case of a persisted
+	// Sequence Match selection over a now-mismatched target (defence in depth).
 	if args.settings.similarityType == "exact-match" && targetSequenceType != assaySequenceType {
-		ll.panic("Exact matching requires the assay and target to use the same alphabet (both amino acid or both nucleotide); got target=%v, assay=%v. Use an alignment mode for cross-alphabet matching.", targetSequenceType, assaySequenceType)
+		ll.panic("Sequence Match requires the assay and target to use the same alphabet (both amino acid or both nucleotide); got target=%v, assay=%v. Use an alignment mode for cross-alphabet matching.", targetSequenceType, assaySequenceType)
 	}
 
 	handleUrl := ll.parseUrl(args.fileHandle)

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -109,6 +109,15 @@ wf.body(func(args) {
 		ll.panic("Assay sequence type is undefined")
 	}
 
+	// Backstop for the exact-match (Identical sequences) mode. String equality
+	// cannot match across alphabets — MMseqs2 handles that via translated
+	// search, exact mode does not. The UI gates the option, this guards the
+	// edge case of a persisted exact-match selection over a now-mismatched
+	// target (defence in depth).
+	if args.settings.similarityType == "exact-match" && targetSequenceType != assaySequenceType {
+		ll.panic("Exact matching requires the assay and target to use the same alphabet (both amino acid or both nucleotide); got target=%v, assay=%v. Use an alignment mode for cross-alphabet matching.", targetSequenceType, assaySequenceType)
+	}
+
 	handleUrl := ll.parseUrl(args.fileHandle)
 	jsonPayload := handleUrl.Path[1:]
 	fileInfo := json.decode(jsonPayload)
@@ -172,6 +181,7 @@ wf.body(func(args) {
 		xsvType: xsvType,
 		sequenceColumnHeader: args.sequenceColumnHeader,
 		clonesFasta: clonesFasta,
+		clonesTsv: clonesTsv,
 		emptyClonesInput: emptyClonesInput,
 		targetSequenceType: targetSequenceType,
 		assaySequenceType: assaySequenceType,


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a third matching mode — "Identical sequences" (`exact-match`) — that performs a case-normalised hash equi-join instead of MMseqs2 alignment, giving guaranteed recall for byte-identical sequences with no alignment overhead.

- A new `runExactMatch` Tengo function emits a fabricated BLAST-tab TSV whose schema matches the MMseqs2 merge output exactly, leaving all downstream post-processing unchanged; the model pins `identity`/`coverage` to 1 and `lessSensitive` to `false` in this mode so hidden controls cannot stale the block.
- A new `targetSequenceType` model output resolves the target column's alphabet and drives UI gating — the "Identical sequences" option is only shown when alphabets match or are unknown, with a `ll.panic` backstop in the workflow guarding persisted mismatches.
- The `PlDropdown` options and the MMseqs2-only fields (score/coverage threshold, fast-mode checkbox) are conditionally rendered based on the active matching mode.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge — the exact-match path is schema-compatible with downstream processing and the workflow backstop guards any persisted alphabet-mismatch edge case.

The two code paths (exact-match and MMseqs2) produce identical output schemas and the downstream post-processing is untouched. The main rough edges are a UI state issue — the `similarityType` value is not auto-reset when the Identical sequences option disappears from the dropdown — and unnecessary FASTA generation in exact-match runs. Neither breaks correctness, but the UI issue means users who switch targets after selecting exact-match will hit a workflow panic rather than a proactive UI reset.

`ui/src/pages/MainPage.vue` — the dropdown value reset on option removal; `workflow/src/main.tpl.tengo` — unconditional FASTA conversion.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| model/src/types.ts | Extends the `similarityType` union to include `'exact-match'` with clear JSDoc explaining its semantics. |
| model/src/label.ts | Adds an early-return branch for `'exact-match'` before the old ternary, so the existing label "Exact Match" for `sequence-identity` is unaffected. |
| model/src/index.ts | Pins MMseqs2-only settings to inert values in exact-match mode and adds `targetSequenceType` output for UI gating; alphabet resolution returns `undefined` when the target column isn't found in matcher results, handled permissively. |
| ui/src/pages/MainPage.vue | Converts `similarityTypeOptions` to a computed ref and conditionally hides MMseqs2-specific controls; the `'exact-match'` value is not auto-reset when the option is removed from the dropdown due to alphabet mismatch. |
| workflow/src/main.tpl.tengo | Adds an alphabet backstop panic for exact-match mode and passes `clonesTsv` to the analysis template; `clonesFasta` is still built unconditionally even when exact-match mode skips it entirely. |
| workflow/src/analysis.tpl.tengo | Adds `runExactMatch` as a full alternative to the MMseqs2 path; fabricated BLAST-tab columns are schema-compatible with downstream post-processing, and the inner join on uppercased sequences is correct. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects Alignment Score dropdown] --> B{similarityType?}
    B -- alignment-score / sequence-identity --> C[MMseqs2 path]
    B -- exact-match --> D[Exact-match path]

    subgraph MMseqs2 path
        C --> C1[runTsvToFasta - assay]
        C1 --> C2[covModeCalc]
        C2 --> C3[splitFasta - 2 chunks]
        C3 --> C4[runAlignment x2]
        C4 --> C5[mergeResults - normalise e-values]
        C5 --> C6[mmseqsResultTsv]
    end

    subgraph Exact-match path
        D --> D1[runExactMatch]
        D1 --> D2[assayDf - toUpper + len]
        D2 --> D3[clonesDf - toUpper]
        D3 --> D4[inner join on sequence equality]
        D4 --> D5[fabricate BLAST-tab columns]
        D5 --> D6[mmseqsResultTsv]
    end

    C6 --> E[checkContentEmpty - require 2 lines]
    D6 --> E
    E --> F[Post-process with PT - groupBy target maxBy bits]
    F --> G[bestAlignmentTsv / assayDataTsv / clonesDataTsv]

    M[model args] -- similarityType==exact-match --> M1[pin identity=1 coverage=1 lessSensitive=false]
    N[model targetSequenceType output] -- resolves alphabet --> UI[UI gate - hide option when alphabets differ]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `workflow/src/main.tpl.tengo`, line 145-159 ([link](https://github.com/platforma-open/immune-assay-data/blob/cd67e1ad2766490f8eac2f03588c8be7cf9e0691/workflow/src/main.tpl.tengo#L145-L159)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unnecessary FASTA conversion in exact-match mode**

   `clonesFasta` is built unconditionally from `clonesTsv` (via `prepareFastaSw`), but in exact-match mode the analysis template uses only `clonesTsv` and never touches `clonesFasta`. The FASTA conversion is thus wasted compute and I/O for every exact-match run. The empty-clone check (`checkClonesRun`) depends on `clonesFasta`, so a refactor would need to either move the emptiness check to operate on the TSV directly, or accept the current cost as a deliberate simplification. Worth noting if runtimes on large clone sets are a concern.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: workflow/src/main.tpl.tengo
   Line: 145-159

   Comment:
   **Unnecessary FASTA conversion in exact-match mode**

   `clonesFasta` is built unconditionally from `clonesTsv` (via `prepareFastaSw`), but in exact-match mode the analysis template uses only `clonesTsv` and never touches `clonesFasta`. The FASTA conversion is thus wasted compute and I/O for every exact-match run. The empty-clone check (`checkClonesRun`) depends on `clonesFasta`, so a refactor would need to either move the emptiness check to operate on the TSV directly, or accept the current cost as a deliberate simplification. Worth noting if runtimes on large clone sets are a concern.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
ui/src/pages/MainPage.vue:255-268
**Stale `exact-match` setting when option is hidden**

When the user already has `exact-match` selected and then switches to a target column with a different alphabet, `knownAndDiffer` becomes `true` and the option is removed from the list — but `app.model.data.settings.similarityType` is never reset to a valid value. The PlDropdown then holds a value that isn't in its options, and the block silently re-runs in `exact-match` mode until the workflow's backstop panic fires. A watcher that reverts `similarityType` (e.g. to `'alignment-score'`) whenever it equals `'exact-match'` but that option is no longer present would give the user immediate feedback instead of a deferred runtime error.

### Issue 2 of 2
workflow/src/main.tpl.tengo:145-159
**Unnecessary FASTA conversion in exact-match mode**

`clonesFasta` is built unconditionally from `clonesTsv` (via `prepareFastaSw`), but in exact-match mode the analysis template uses only `clonesTsv` and never touches `clonesFasta`. The FASTA conversion is thus wasted compute and I/O for every exact-match run. The empty-clone check (`checkClonesRun`) depends on `clonesFasta`, so a refactor would need to either move the emptiness check to operate on the TSV directly, or accept the current cost as a deliberate simplification. Worth noting if runtimes on large clone sets are a concern.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Introduce sequence identity matching mod..."](https://github.com/platforma-open/immune-assay-data/commit/cd67e1ad2766490f8eac2f03588c8be7cf9e0691) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34594591)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->