### PR TITLE
Complete block-tools structurer migration

### DIFF
--- a/.changeset/complete-structurer-migration.md
+++ b/.changeset/complete-structurer-migration.md
@@ -1,0 +1,9 @@
+---
+'@platforma-open/milaboratories.immune-assay-data': patch
+---
+
+Complete the block-tools structurer migration: move the block facade to the
+managed `block/src` layout and regenerate the package manifests and CI
+workflows. This adds the `--registry-serve-url` flag that the bumped block-tools
+now requires for `block-tools publish`, fixing the block-registry publish step
+that failed after the SDK bump.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,8 @@ jobs:
       node-version: '20.x'
       build-script-name: 'build'
       pnpm-recursive-build: false
-      test: false
+
+      test: true
       test-script-name: 'test'
       pnpm-recursive-tests: false
       team-id: 'ciplopen'
@@ -54,14 +55,13 @@ jobs:
           "PL_CI_TEST_PASSWORD": ${{ toJSON(secrets.PL_CI_TEST_PASSWORD) }},
 
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
-          "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_US_S3_BUCKET) }},
+          "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
           "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
-          
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }
 
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       GH_ZEN_APP_ID: ${{ secrets.GH_ZEN_APP_ID }}
       GH_ZEN_APP_PRIVATE_KEY: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}

--- a/.github/workflows/mark-stable.yaml
+++ b/.github/workflows/mark-stable.yaml
@@ -30,5 +30,5 @@ jobs:
         { "NPMJS_TOKEN": ${{ toJSON(secrets.NPMJS_TOKEN) }},
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }} }
 
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/block/index.d.ts
+++ b/block/index.d.ts
@@ -1,6 +1,0 @@
-declare const blockSpec: {
-  type: "dev-v2";
-  folder: string;
-};
-
-export { blockSpec };

--- a/block/index.js
+++ b/block/index.js
@@ -1,8 +1,0 @@
-const blockSpec = {
-  type: "dev-v2",
-  folder: __dirname,
-};
-
-module.exports = {
-  blockSpec,
-};

--- a/block/package.json
+++ b/block/package.json
@@ -2,23 +2,37 @@
   "name": "@platforma-open/milaboratories.immune-assay-data",
   "version": "1.5.2",
   "files": [
-    "index.d.ts",
-    "index.js"
+    "dist",
+    "block-pack"
   ],
-  "scripts": {
-    "build": "shx rm -rf ./block-pack && block-tools pack",
-    "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "do-pack": "shx rm -f *.tgz && block-tools pack && pnpm pack && shx mv *.tgz package.tgz"
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "sources": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "dependencies": {
+  "scripts": {
+    "build": "ts-builder build --target block-facade && block-tools pack",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
+    "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
+    "check": "ts-builder type-check --target block-facade"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@milaboratories/ts-builder": "catalog:",
+    "@milaboratories/ts-configs": "catalog:",
     "@platforma-open/milaboratories.immune-assay-data.model": "workspace:*",
     "@platforma-open/milaboratories.immune-assay-data.ui": "workspace:*",
-    "@platforma-open/milaboratories.immune-assay-data.workflow": "workspace:*"
-  },
-  "devDependencies": {
+    "@platforma-open/milaboratories.immune-assay-data.workflow": "workspace:*",
     "@platforma-sdk/block-tools": "catalog:",
-    "shx": "catalog:"
+    "@platforma-sdk/model": "catalog:",
+    "shx": "catalog:",
+    "typescript": "catalog:"
   },
   "packageManager": "pnpm@9.12.0",
   "block": {

--- a/block/src/AGENTS.ts
+++ b/block/src/AGENTS.ts
@@ -1,0 +1,5 @@
+// This file is managed by `block-tools structure`. Do not edit by hand.
+// Narrow MCP / AI surface.
+
+export type { BlockContract, BlockOutputs, BlockData } from "./index";
+export * from "./agents-extra";

--- a/block/src/agents-extra.ts
+++ b/block/src/agents-extra.ts
@@ -1,0 +1,8 @@
+// Author-owned. `block-tools structure` does not modify this file.
+// MCP / AI extension surface. Add types and functions the agent
+// surface should expose.
+//
+// In the future this file will host JS functions the MCP runtime
+// can execute. The `.d.ts` declarations stay visible to the agent;
+// the JS bodies execute in the MCP code-execution context (the
+// agent sees the types but not the implementation).

--- a/block/src/block-extra.ts
+++ b/block/src/block-extra.ts
@@ -1,0 +1,9 @@
+// Author-owned. `block-tools structure` does not modify this file.
+// Add block-specific helper types or values the consumer surface
+// should expose. Anything you `export` here flows out via the
+// main entry (./index re-exports this file).
+//
+// Do NOT redefine: BlockContract, BlockOutputs, BlockData,
+// BlockPointer, platforma, or the block-named <PascalName>Block*
+// aliases — those names come from ./index and `export *` from this
+// file would shadow them.

--- a/block/src/index.ts
+++ b/block/src/index.ts
@@ -1,0 +1,55 @@
+// This file is managed by `block-tools structure`. Do not edit by hand.
+// Author content lives in ./block-extra.ts.
+
+import { platforma } from "@platforma-open/milaboratories.immune-assay-data.model";
+import {
+  InferOutputsType,
+  InferDataType,
+  InferHrefType,
+} from "@platforma-sdk/model";
+
+export { platforma };
+
+export type BlockContract = {
+  outputs: InferOutputsType<typeof platforma>;
+  data:    InferDataType<typeof platforma>;
+  href:    InferHrefType<typeof platforma>;
+};
+
+export type BlockOutputs = BlockContract["outputs"];
+export type BlockData    = BlockContract["data"];
+
+// import.meta.url is a file: URL (always forward-slash, even on Windows:
+// file:///C:/…). We expose URLs, NOT paths — the facade stays dependency-free
+// and loadable in minimal engines (e.g. QuickJS), and each consumer converts
+// at its own edge with the right tool (fileURLToPath in Node), where Windows
+// drive letters / %-encoding / UNC are handled correctly. The bundled entry
+// sits one dir under the package root (dist/index.js, or src/index.ts in dev),
+// so the root is two URL segments up. The structurer owns this layout —
+// consumers read these URLs, they never reconstruct <root>/block-pack.
+//
+// TypeScript ships `ImportMeta.url` only in the `dom`/`webworker` libs; the
+// facade tsconfig is lib-minimal (no `dom`, no `@types/node`) by design. We
+// type the one ESM-standard member we use with a local cast rather than a
+// `declare global` — a global augmentation would leak into the published
+// `dist/index.d.ts` and clash with `@types/node`'s `ImportMeta` in full-Node
+// consumers (test packages, the Middle Layer).
+const selfUrl = (import.meta as ImportMeta & { url: string }).url;
+const dirUrl  = selfUrl.slice(0, selfUrl.lastIndexOf("/"));
+const rootUrl = dirUrl.slice(0, dirUrl.lastIndexOf("/"));
+
+export const BlockPointer = {
+  type: "from-pack-v2" as const,
+  packUrl: rootUrl + "/block-pack",
+  rootUrl,
+} as const;
+
+// Block-named aliases for readable cross-block imports in tests and
+// consumer code. Same types / same runtime value as the universal
+// names above; the aliases avoid `as`-renames at the import site.
+export type ImmuneAssayDataBlockContract = BlockContract;
+export type ImmuneAssayDataBlockOutputs  = BlockOutputs;
+export type ImmuneAssayDataBlockData     = BlockData;
+export const ImmuneAssayDataBlockPointer = BlockPointer;
+
+export * from "./block-extra";

--- a/block/tsconfig.json
+++ b/block/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@milaboratories/ts-configs/block/facade",
+  "include": ["src/**/*"]
+}

--- a/model/package.json
+++ b/model/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.model",
   "version": "1.10.2",
+  "private": true,
   "description": "Block model",
   "type": "module",
   "main": "dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,13 @@ importers:
         version: 5.6.3
 
   block:
-    dependencies:
+    devDependencies:
+      '@milaboratories/ts-builder':
+        specifier: 'catalog:'
+        version: 1.6.0(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
+      '@milaboratories/ts-configs':
+        specifier: 'catalog:'
+        version: 1.3.0
       '@platforma-open/milaboratories.immune-assay-data.model':
         specifier: workspace:*
         version: link:../model
@@ -117,13 +123,18 @@ importers:
       '@platforma-open/milaboratories.immune-assay-data.workflow':
         specifier: workspace:*
         version: link:../workflow
-    devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
         version: 2.11.5(@types/node@24.5.2)
+      '@platforma-sdk/model':
+        specifier: 'catalog:'
+        version: 1.79.20
       shx:
         specifier: 'catalog:'
         version: 0.4.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
 
   model:
     dependencies:
@@ -1219,12 +1230,6 @@ packages:
 
   '@milaboratories/uikit@2.15.11':
     resolution: {integrity: sha512-oBQiPXpHEwg1dLptfCQNtpRrJ3stunjrTWiP5U90rAXl4c6Z/Ks7YU/fVvoqdBsoSBQ6nEcAG0Sk4sV8DVRlJQ==}
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3658,9 +3663,6 @@ packages:
     resolution: {integrity: sha512-RLGFxPNgY9AtVVrFGdKO6Y3pOd/Ov2WA4O2/czZN/AbgYzbPdoF0KkfvHRIney6k+TtvoyYB8YqZXJ4G88f9BQ==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -8060,7 +8062,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3))
+      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8101,7 +8103,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3))
+      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8174,11 +8176,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -8739,7 +8741,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.3':
@@ -11312,11 +11314,6 @@ snapshots:
       '@stdlib/utils-constructor-name': 0.2.2
       '@stdlib/utils-global': 0.2.2
 
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
@@ -13273,7 +13270,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3)):
+  rolldown-plugin-dts@0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2

--- a/software/add-header/package.json
+++ b/software/add-header/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.add-header",
   "version": "1.1.4",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/check-content-empty/package.json
+++ b/software/check-content-empty/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.check-content-empty",
   "version": "1.0.2",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/coverage-mode-calc/package.json
+++ b/software/coverage-mode-calc/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.coverage-mode-calc",
   "version": "1.3.1",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/fasta-to-tsv/package.json
+++ b/software/fasta-to-tsv/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.fasta-to-tsv",
   "version": "1.1.4",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/merge-results/package.json
+++ b/software/merge-results/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.merge-results",
   "version": "1.1.1",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/prepare-fasta/package.json
+++ b/software/prepare-fasta/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.prepare-fasta",
   "version": "1.1.4",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/sequence-match/package.json
+++ b/software/sequence-match/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.sequence-match",
   "version": "1.1.1",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/split-fasta/package.json
+++ b/software/split-fasta/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.split-fasta",
   "version": "1.2.1",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/xlsx-to-csv/package.json
+++ b/software/xlsx-to-csv/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.xlsx-to-csv",
   "version": "1.1.1",
+  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.ui",
   "version": "1.9.2",
+  "private": true,
   "type": "module",
   "scripts": {
     "build": "ts-builder build --target block-ui",

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.workflow",
   "version": "1.14.2",
+  "private": true,
   "description": "Tengo-based template",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The deps-only SDK update bumped block-tools to 2.11.5 but left the managed package manifests stale. block-tools 2.11.5 makes --registry-serve-url mandatory for `block-tools publish`, so the block-facade publish step failed in CI.

Run the full structure refresh to regenerate the managed layout: move the facade to block/src, mark bundled component and software packages private, regenerate CI workflows, and add the required --registry-serve-url flag to prepublishOnly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the `block-tools` structurer migration by replacing the hand-written CJS facade (`block/index.js` / `block/index.d.ts`) with a generated ESM TypeScript facade under `block/src/`, and regenerates the CI workflows and package manifests. The immediate motivation is that `block-tools 2.11.5` made `--registry-serve-url` mandatory for `block-tools publish`, which was missing and broke the CI publish step.

- **Facade migration**: Old `blockSpec` / `dev-v2` / `__dirname` CJS contract replaced by `BlockPointer` / `from-pack-v2` / `import.meta.url`-based URL resolution; new `AGENTS.ts` exposes a narrow MCP/AI surface; all three are managed by `block-tools structure` going forward.
- **Package hygiene**: All component sub-packages (model, ui, workflow, software/*) marked `private: true`; their workspace references in `block/package.json` moved to `devDependencies` since they are bundled by `ts-builder`.
- **CI fixes**: Secret name corrected (`AWS_CI_TURBOREPO_US_S3_BUCKET` \u2192 `AWS_CI_TURBOREPO_S3_BUCKET`), tests re-enabled, and Slack parameters reordered.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The structural migration is correct and well-reasoned; the two items worth a second look are the unquoted S3 URL and the missing changeset entry for the public block package.

The S3 URL in prepublishOnly lost the single-quote wrapping present in the old script, leaving ?region=eu-central-1 technically shell-unsafe. The changeset lists only private packages, so the public block package whose entire exported API changed from blockSpec to BlockPointer won't get an npm version bump from this PR.

.changeset/complete-structurer-migration.md and block/package.json prepublishOnly script.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| block/package.json | Migrated from CJS (index.js/index.d.ts) to ESM facade (dist/); added --registry-serve-url to prepublishOnly; workspace deps moved to devDependencies; S3 URL is now unquoted (minor shell-glob risk). |
| block/src/index.ts | New managed ESM facade; replaces old blockSpec/dev-v2 with BlockPointer/from-pack-v2 using import.meta.url for URL-based block-pack resolution; well-commented to explain the ImportMeta typing workaround. |
| .changeset/complete-structurer-migration.md | Changeset bumps ui/model/workflow (all now private, so not npm-published) but omits the public block package whose API changed entirely. |
| .github/workflows/build.yaml | Re-enabled tests (test: false to true), fixed turborepo S3 secret name (removed US suffix), reordered SLACK env params; overall correct regeneration. |
| block/src/AGENTS.ts | New managed file defining a narrow MCP/AI surface by re-exporting BlockContract, BlockOutputs, BlockData and the agents-extra extension point. |
| block/tsconfig.json | New tsconfig extending @milaboratories/ts-configs/block/facade with src/**/* coverage; standard managed layout. |
| model/package.json | Added private: true; component packages are not meant for standalone npm publication. |
| ui/package.json | Added private: true; consistent with the other component sub-packages. |
| workflow/package.json | Added private: true; consistent with the other component sub-packages. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["block/src/index.ts\nManaged ESM facade"] -->|imports platforma| B["model package\nprivate: true"]
    A -->|InferOutputsType etc| C["@platforma-sdk/model\ncatalog:"]
    A -->|export star| D["block-extra.ts\nauthor-owned"]
    A --> E["dist/index.js\nbundled by ts-builder"]
    E --> F["block-pack/\nblock-tools pack"]

    subgraph CI ["CI publish"]
        G["build.yaml\ntest: true"]
        G --> H["ts-builder build\n--target block-facade"]
        H --> I["block-tools pack"]
        I --> J["block-tools publish\n-r s3://...\n--registry-serve-url\nhttps://blocks.pl-open.science"]
    end

    F --> J
    E --> K["npm package\nv1.5.2\nnot in changeset"]

    subgraph AGENTS ["MCP surface"]
        L["AGENTS.ts\nBlockContract, BlockOutputs\nBlockData + agents-extra"]
    end
    A --> L
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["block/src/index.ts\nManaged ESM facade"] -->|imports platforma| B["model package\nprivate: true"]
    A -->|InferOutputsType etc| C["@platforma-sdk/model\ncatalog:"]
    A -->|export star| D["block-extra.ts\nauthor-owned"]
    A --> E["dist/index.js\nbundled by ts-builder"]
    E --> F["block-pack/\nblock-tools pack"]

    subgraph CI ["CI publish"]
        G["build.yaml\ntest: true"]
        G --> H["ts-builder build\n--target block-facade"]
        H --> I["block-tools pack"]
        I --> J["block-tools publish\n-r s3://...\n--registry-serve-url\nhttps://blocks.pl-open.science"]
    end

    F --> J
    E --> K["npm package\nv1.5.2\nnot in changeset"]

    subgraph AGENTS ["MCP surface"]
        L["AGENTS.ts\nBlockContract, BlockOutputs\nBlockData + agents-extra"]
    end
    A --> L
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ablock%2Fpackage.json%3A21%0AThe%20S3%20URL%20passed%20to%20%60-r%60%20is%20no%20longer%20quoted.%20The%20%60%3Fregion%3Deu-central-1%60%20segment%20contains%20%60%3F%60%2C%20which%20is%20a%20shell%20glob%20wildcard%20%28matches%20any%20single%20character%29.%20In%20the%20default%20bash%2Fsh%20%60nullglob%60-off%20configuration%20the%20literal%20is%20passed%20through%20when%20no%20filename%20matches%2C%20so%20the%20publish%20currently%20works%2C%20but%20it's%20fragile%20%E2%80%94%20a%20file%20named%20e.g.%20%60region%3Deu-central-1%60%20in%20the%20working%20directory%20during%20publish%20would%20corrupt%20the%20argument.%20The%20old%20%60prepublishOnly%60%20single-quoted%20the%20URL%3B%20the%20new%20one%20should%20too.%0A%0A%60%60%60suggestion%0A%20%20%20%20%22prepublishOnly%22%3A%20%22block-tools%20publish%20-r%20's3%3A%2F%2Fmilab-euce1-prod-pkgs-s3-block-registry%2Fpub%2Freleases%2F%3Fregion%3Deu-central-1'%20--registry-serve-url%20https%3A%2F%2Fblocks.pl-open.science%22%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.changeset%2Fcomplete-structurer-migration.md%3A1-5%0A**Changeset%20covers%20private%20packages%20but%20omits%20the%20public%20block%20package**%0A%0AThe%20changeset%20bumps%20%60ui%60%2C%20%60model%60%2C%20and%20%60workflow%60%2C%20all%20of%20which%20are%20now%20marked%20%60private%3A%20true%60%20%28changesets%20skips%20private%20packages%20on%20publish%29.%20The%20main%20public%20package%20%60%40platforma-open%2Fmilaboratories.immune-assay-data%60%20is%20not%20listed%2C%20even%20though%20its%20entire%20exported%20API%20changed%20%E2%80%94%20the%20old%20CJS%20%60blockSpec%60%20%2F%20%60dev-v2%60%20surface%20was%20removed%20and%20replaced%20with%20ESM%20%60BlockPointer%60%20%2F%20%60from-pack-v2%60.%20Without%20a%20changeset%20entry%20for%20the%20public%20package%20its%20npm%20version%20stays%20at%201.5.2%2C%20so%20consumers%20who%20watch%20the%20registry%20won't%20see%20a%20version%20signal%20for%20the%20breaking%20rename.%0A%0A&repo=platforma-open%2Fimmune-assay-data&pr=54&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
block/package.json:21
The S3 URL passed to `-r` is no longer quoted. The `?region=eu-central-1` segment contains `?`, which is a shell glob wildcard (matches any single character). In the default bash/sh `nullglob`-off configuration the literal is passed through when no filename matches, so the publish currently works, but it's fragile — a file named e.g. `region=eu-central-1` in the working directory during publish would corrupt the argument. The old `prepublishOnly` single-quoted the URL; the new one should too.

```suggestion
    "prepublishOnly": "block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1' --registry-serve-url https://blocks.pl-open.science",
```

### Issue 2 of 2
.changeset/complete-structurer-migration.md:1-5
**Changeset covers private packages but omits the public block package**

The changeset bumps `ui`, `model`, and `workflow`, all of which are now marked `private: true` (changesets skips private packages on publish). The main public package `@platforma-open/milaboratories.immune-assay-data` is not listed, even though its entire exported API changed — the old CJS `blockSpec` / `dev-v2` surface was removed and replaced with ESM `BlockPointer` / `from-pack-v2`. Without a changeset entry for the public package its npm version stays at 1.5.2, so consumers who watch the registry won't see a version signal for the breaking rename.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Complete block-tools structurer migratio..."](https://github.com/platforma-open/immune-assay-data/commit/3e4ea4e9963a6cf60565aa4c4f54ab72aab3fe65) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40617255)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->