### PR TITLE
Upgrade SDK

### DIFF
--- a/.changeset/wild-bees-leave.md
+++ b/.changeset/wild-bees-leave.md
@@ -1,0 +1,14 @@
+---
+"@platforma-open/milaboratories.immune-assay-data.check-content-empty": patch
+"@platforma-open/milaboratories.immune-assay-data.coverage-mode-calc": patch
+"@platforma-open/milaboratories.immune-assay-data.sequence-match": patch
+"@platforma-open/milaboratories.immune-assay-data.merge-results": patch
+"@platforma-open/milaboratories.immune-assay-data.prepare-fasta": patch
+"@platforma-open/milaboratories.immune-assay-data.fasta-to-tsv": patch
+"@platforma-open/milaboratories.immune-assay-data.split-fasta": patch
+"@platforma-open/milaboratories.immune-assay-data.xlsx-to-csv": patch
+"@platforma-open/milaboratories.immune-assay-data.add-header": patch
+"@platforma-open/milaboratories.immune-assay-data": patch
+---
+
+Upgrade SDK

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.11.5
-      version: 2.11.5
+      specifier: 2.11.6
+      version: 2.11.6
     '@platforma-sdk/model':
       specifier: 1.79.20
       version: 1.79.20
@@ -49,8 +49,8 @@ catalogs:
       specifier: 4.0.11
       version: 4.0.11
     '@platforma-sdk/test':
-      specifier: 1.79.22
-      version: 1.79.22
+      specifier: 1.79.23
+      version: 1.79.23
     '@platforma-sdk/ui-vue':
       specifier: 1.79.20
       version: 1.79.20
@@ -95,7 +95,7 @@ importers:
         version: 1.6.0(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.5.2)
+        version: 2.11.6(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -125,7 +125,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.5.2)
+        version: 2.11.6(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.79.20
@@ -162,7 +162,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.5(@types/node@24.5.2)
+        version: 2.11.6(@types/node@24.5.2)
       eslint:
         specifier: 'catalog:'
         version: 9.27.0
@@ -338,7 +338,7 @@ importers:
         version: 4.0.11
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.22(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.0))
+        version: 1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.0))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -1180,8 +1180,8 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.40':
-    resolution: {integrity: sha512-d71/T3zlTtunFgVum28FLhlZuKuwpT591B2ZfZVO6Jamd8nY54CxcBmIsIG4xVTqitvsQhNFiAJdkoYgXE6Inw==}
+  '@milaboratories/pl-middle-layer@1.64.41':
+    resolution: {integrity: sha512-6xXwmTaaImd6HQ2PZgUWGf1gXsfgEPz3zWQsmaUaPMyMusjPVynPCX2hnThqrPVf54mEMlvc3HTGaC+dofDF0g==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.9':
@@ -1583,8 +1583,8 @@ packages:
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3':
     resolution: {integrity: sha512-npV+3LXmQNaX5/QsqtsRr5i0oLG7Uu5p51pI27WA2AbN2iyEUbHwbELhEwU26rkdzKTukCvCzs3NTuxIxQy7vQ==}
 
-  '@platforma-sdk/block-tools@2.11.5':
-    resolution: {integrity: sha512-dM4KLiJLz3zQgJfJklq9M8/Q5yTIiaDLZ2ui1o0fsKoe3wB+cGA0VJCNAjjgLeKmvZd6zqd+2OmXpCn5pOBn+g==}
+  '@platforma-sdk/block-tools@2.11.6':
+    resolution: {integrity: sha512-CyekNfqEildNeTrkjAeaWC7ah+skGMb3d/crSZSgCWACPIVQwg2oRZiJliwmJU/ylcTONPDAef7DYOtmfXsgtw==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1606,8 +1606,8 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.22':
-    resolution: {integrity: sha512-So8pT0S0+bDmLHdhPPmHRz3cDdNeghDybL3dfbMKittrKF27WD6FaUqFOV96CtPpo4/bhDnZ8wL4ZUdXKChynA==}
+  '@platforma-sdk/test@1.79.23':
+    resolution: {integrity: sha512-vb5K4Rtjy5ogom3fBYpOxvKL+Nb50iURUdd1vjzN3pcQGx47omBnDr9YvNvUsRC3INhZibLzy44dUKD2la/IMw==}
 
   '@platforma-sdk/ui-vue@1.79.20':
     resolution: {integrity: sha512-VwBG8MKV1M2KMR2PgW+o6uxJJRCFGihaRsnkzLL8HGKM/Vr9k3FY/V929B1XAhU5y9wb1g7fKNJvy9JNEq5GiQ==}
@@ -5347,9 +5347,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -7959,7 +7956,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.40(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
@@ -7978,7 +7975,7 @@ snapshots:
       '@milaboratories/pl-tree': 1.12.14
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/block-tools': 2.11.5(@types/node@24.5.2)
+      '@platforma-sdk/block-tools': 2.11.6(@types/node@24.5.2)
       '@platforma-sdk/model': 1.79.20
       '@platforma-sdk/workflow-tengo': 6.6.5
       canonicalize: 2.1.0
@@ -8062,7 +8059,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3))
+      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8103,7 +8100,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.1.3
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3))
+      rolldown-plugin-dts: 0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.55.1)
       typescript: 5.9.3
@@ -8469,7 +8466,7 @@ snapshots:
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.3': {}
 
-  '@platforma-sdk/block-tools@2.11.5(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.11.6(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
@@ -8543,11 +8540,11 @@ snapshots:
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.79.22(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.0))':
+  '@platforma-sdk/test@1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.0))':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-middle-layer': 1.64.40(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.12.14
       '@platforma-sdk/model': 1.79.20
       '@vitest/coverage-istanbul': 4.1.9(vitest@4.1.9)
@@ -11412,7 +11409,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.1
+      obug: 2.1.3
       tinyrainbow: 3.1.0
       vitest: 4.1.9(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.9)(vite@8.0.10(@types/node@24.5.2)(sass-embedded@1.89.0)(yaml@2.8.0))
     transitivePeerDependencies:
@@ -12935,8 +12932,6 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  obug@2.1.1: {}
-
   obug@2.1.3: {}
 
   once@1.4.0:
@@ -13270,7 +13265,7 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.6.3)):
+  rolldown-plugin-dts@0.26.0(rolldown@1.1.3)(typescript@5.9.3)(vue-tsc@3.3.5(typescript@5.9.3)):
     dependencies:
       '@babel/generator': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
@@ -13926,7 +13921,7 @@ snapshots:
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,8 +22,8 @@ catalog:
   '@platforma-sdk/ui-vue': 1.79.20
   '@platforma-sdk/tengo-builder': 4.0.11
   '@platforma-sdk/package-builder': 3.14.0
-  '@platforma-sdk/block-tools': 2.11.5
-  '@platforma-sdk/test': 1.79.22
+  '@platforma-sdk/block-tools': 2.11.6
+  '@platforma-sdk/test': 1.79.23
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/graph-maker': 1.4.8
   '@milaboratories/multi-sequence-alignment': 1.47.18

--- a/software/add-header/package.json
+++ b/software/add-header/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.add-header",
   "version": "1.1.5",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/check-content-empty/package.json
+++ b/software/check-content-empty/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.check-content-empty",
   "version": "1.0.3",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/coverage-mode-calc/package.json
+++ b/software/coverage-mode-calc/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.coverage-mode-calc",
   "version": "1.3.2",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/fasta-to-tsv/package.json
+++ b/software/fasta-to-tsv/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.fasta-to-tsv",
   "version": "1.1.5",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/merge-results/package.json
+++ b/software/merge-results/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.merge-results",
   "version": "1.1.2",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/prepare-fasta/package.json
+++ b/software/prepare-fasta/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.prepare-fasta",
   "version": "1.1.5",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/sequence-match/package.json
+++ b/software/sequence-match/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.sequence-match",
   "version": "1.1.2",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/split-fasta/package.json
+++ b/software/split-fasta/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.split-fasta",
   "version": "1.2.2",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],

--- a/software/xlsx-to-csv/package.json
+++ b/software/xlsx-to-csv/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@platforma-open/milaboratories.immune-assay-data.xlsx-to-csv",
   "version": "1.1.2",
-  "private": true,
   "files": [
     "./dist/**/*"
   ],


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades two Platforma SDK packages (`@platforma-sdk/block-tools` from `2.11.5` → `2.11.6`, `@platforma-sdk/test` from `1.79.22` → `1.79.23`) across the workspace, and removes the `"private": true` field from all nine `software/*/package.json` sub-packages.

- **SDK bumps**: `@platforma-sdk/block-tools` and `@platforma-sdk/test` receive patch updates; transitively, `@milaboratories/pl-middle-layer` moves from `1.64.40` → `1.64.41` and `obug` from `2.1.1` → `2.1.3`.
- **`private: true` removal**: All nine software sub-packages (`add-header`, `check-content-empty`, `coverage-mode-calc`, `fasta-to-tsv`, `merge-results`, `prepare-fasta`, `sequence-match`, `split-fasta`, `xlsx-to-csv`) lose the `"private": true` guard, making them publishable to a registry. A matching changeset (`wild-bees-leave.md`) assigns patch bumps to all of them.
- **Lock-file side-effect**: The TypeScript version used by `vue-tsc` inside the `rolldown-plugin-dts` peer-dependency snapshot shifts from `typescript@5.6.3` to `typescript@5.9.3` as a consequence of the `block-tools` upgrade.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge if the removal of "private": true from all nine software packages is intentional; the SDK bumps are patch-level and low risk.

The SDK version bumps are straightforward patch upgrades with no source-code changes. The only non-trivial change is the removal of "private": true across all nine software sub-packages, which enables their publication via changeset — this appears intentional given the accompanying changeset file, but deserves explicit confirmation before merging. A lock-file side-effect shifts the vue-tsc TypeScript peer from 5.6.3 to 5.9.3 inside rolldown-plugin-dts, which is invisible to runtime but could surface type-generation differences.

All nine software/*/package.json files warrant a quick confirmation that publishing them externally is intended.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Catalog entries for @platforma-sdk/block-tools (2.11.5→2.11.6) and @platforma-sdk/test (1.79.22→1.79.23) bumped; straightforward version pin update. |
| pnpm-lock.yaml | Lockfile regenerated for the two SDK bumps; notable side-effect: rolldown-plugin-dts snapshot shifts vue-tsc peer from typescript@5.6.3 to typescript@5.9.3, and obug bumps from 2.1.1 to 2.1.3. |
| .changeset/wild-bees-leave.md | New changeset assigning patch bumps to all nine software sub-packages and the root package, consistent with the private→public transition. |
| software/add-header/package.json | Removed "private": true — package is now publishable to a registry. |
| software/check-content-empty/package.json | Removed "private": true — package is now publishable to a registry. |
| software/coverage-mode-calc/package.json | Removed "private": true — package is now publishable to a registry. |
| software/fasta-to-tsv/package.json | Removed "private": true — package is now publishable to a registry. |
| software/merge-results/package.json | Removed "private": true — package is now publishable to a registry. |
| software/prepare-fasta/package.json | Removed "private": true — package is now publishable to a registry. |
| software/sequence-match/package.json | Removed "private": true — package is now publishable to a registry. |
| software/split-fasta/package.json | Removed "private": true — package is now publishable to a registry. |
| software/xlsx-to-csv/package.json | Removed "private": true — package is now publishable to a registry. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant WS as pnpm-workspace.yaml (catalog)
    participant BT as @platforma-sdk/block-tools 2.11.5→2.11.6
    participant TEST as @platforma-sdk/test 1.79.22→1.79.23
    participant ML as @milaboratories/pl-middle-layer 1.64.40→1.64.41
    participant OBUG as obug 2.1.1→2.1.3
    participant RD as rolldown-plugin-dts vue-tsc ts@5.6.3→ts@5.9.3
    participant SW as software/* packages (private:true removed)
    participant CS as .changeset/wild-bees-leave.md (patch bumps)

    WS->>BT: bump catalog pin
    WS->>TEST: bump catalog pin
    BT->>RD: peer resolution update
    TEST->>ML: transitive bump
    TEST->>OBUG: transitive bump
    SW->>CS: now publishable (private removed)
    CS-->>SW: patch version bump on release
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant WS as pnpm-workspace.yaml (catalog)
    participant BT as @platforma-sdk/block-tools 2.11.5→2.11.6
    participant TEST as @platforma-sdk/test 1.79.22→1.79.23
    participant ML as @milaboratories/pl-middle-layer 1.64.40→1.64.41
    participant OBUG as obug 2.1.1→2.1.3
    participant RD as rolldown-plugin-dts vue-tsc ts@5.6.3→ts@5.9.3
    participant SW as software/* packages (private:true removed)
    participant CS as .changeset/wild-bees-leave.md (patch bumps)

    WS->>BT: bump catalog pin
    WS->>TEST: bump catalog pin
    BT->>RD: peer resolution update
    TEST->>ML: transitive bump
    TEST->>OBUG: transitive bump
    SW->>CS: now publishable (private removed)
    CS-->>SW: patch version bump on release
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asoftware%2Fadd-header%2Fpackage.json%3A1-3%0A**%60private%3A%20true%60%20removed%20from%20all%20nine%20software%20packages**%0A%0AAll%20nine%20%60software%2F*%2Fpackage.json%60%20files%20have%20had%20%60%22private%22%3A%20true%60%20removed%20in%20this%20PR%20%28%60add-header%60%2C%20%60check-content-empty%60%2C%20%60coverage-mode-calc%60%2C%20%60fasta-to-tsv%60%2C%20%60merge-results%60%2C%20%60prepare-fasta%60%2C%20%60sequence-match%60%2C%20%60split-fasta%60%2C%20%60xlsx-to-csv%60%29.%20This%20guard%20previously%20prevented%20accidental%20registry%20publishes%3B%20its%20removal%20means%20the%20next%20changeset%20release%20will%20publish%20all%20of%20them.%20The%20accompanying%20changeset%20file%20confirms%20this%20is%20likely%20intentional%2C%20but%20it's%20worth%20double-checking%3A%20were%20these%20packages%20previously%20intentionally%20kept%20private%2C%20or%20is%20this%20the%20first%20time%20they%20are%20being%20opened%20for%20external%20consumption%3F%0A%0A&repo=platforma-open%2Fimmune-assay-data&pr=56&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
software/add-header/package.json:1-3
**`private: true` removed from all nine software packages**

All nine `software/*/package.json` files have had `"private": true` removed in this PR (`add-header`, `check-content-empty`, `coverage-mode-calc`, `fasta-to-tsv`, `merge-results`, `prepare-fasta`, `sequence-match`, `split-fasta`, `xlsx-to-csv`). This guard previously prevented accidental registry publishes; its removal means the next changeset release will publish all of them. The accompanying changeset file confirms this is likely intentional, but it's worth double-checking: were these packages previously intentionally kept private, or is this the first time they are being opened for external consumption?

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Upgrade SDK"](https://github.com/platforma-open/immune-assay-data/commit/700a453e72400517a3a7ab5f114b514c73282cd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40854224)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->