### PR TITLE
Milab 6745 empty column import

### DIFF
--- a/.changeset/empty-column-import.md
+++ b/.changeset/empty-column-import.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.immune-assay-data.ui': patch
+---
+
+Handle empty columns in imported assay files: fully empty headerless columns are skipped, and a headerless column that contains data now produces a clear import error instead of crashing the workflow prerun with "invalid index type: undefined". The header-uniqueness check now applies to named columns only.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.12.13
-      version: 2.12.13
+      specifier: 2.13.0
+      version: 2.13.0
     '@platforma-sdk/model':
       specifier: 1.81.1
       version: 1.81.1
@@ -92,7 +92,7 @@ importers:
         version: 1.6.2(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -122,7 +122,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.81.1
@@ -159,7 +159,7 @@ importers:
         version: 1.4.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
       eslint:
         specifier: 'catalog:'
         version: 9.27.0
@@ -171,7 +171,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/check-content-empty:
     devDependencies:
@@ -180,7 +180,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/coverage-mode-calc:
     devDependencies:
@@ -189,7 +189,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/fasta-to-tsv:
     devDependencies:
@@ -198,7 +198,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/merge-results:
     devDependencies:
@@ -207,7 +207,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/prepare-fasta:
     devDependencies:
@@ -216,7 +216,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/sequence-match:
     devDependencies:
@@ -225,7 +225,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/split-fasta:
     devDependencies:
@@ -234,7 +234,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   software/xlsx-to-csv:
     devDependencies:
@@ -243,7 +243,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.13.0(@types/node@24.5.2)
 
   ui:
     dependencies:
@@ -1596,6 +1596,10 @@ packages:
     resolution: {integrity: sha512-eWUIjK6D2/Ce779uyOGw9pET6KOQ7FKHg+DDrrkGh/ZllE2f/f4mghc/FPeOJIBQXVGg7Jg01oWh08SYVBzB5w==}
     hasBin: true
 
+  '@platforma-sdk/block-tools@2.13.0':
+    resolution: {integrity: sha512-xKiTmNLjfxCnnHRr9Q4ct3HdjLfkbLztvxpU++/pek0R8Bj/Lezeoji+eLpxAAYYUxjMr8jLj935eLK5MqKrSg==}
+    hasBin: true
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
@@ -1605,6 +1609,9 @@ packages:
 
   '@platforma-sdk/package-builder-lib@1.2.1':
     resolution: {integrity: sha512-H6weitj7JxbiJSlteEFLafTJ+tfty6iv/imf3ysy8oCS8AZIRJk2VMW3M/aAc+xVkQeX7oVIwMwFMYrJIoFsAg==}
+
+  '@platforma-sdk/package-builder-lib@1.3.0':
+    resolution: {integrity: sha512-CdBjmNo6E1fBxKYWaXa49L/L2WLURxs2f1TAqxLIZlHRE4DZ6E1TEj3jNNKESWp+/9rwtLkTAzmTzNPrDgz+2Q==}
 
   '@platforma-sdk/tengo-builder@4.0.22':
     resolution: {integrity: sha512-8+zDYDFFI2tQS7dplTcxgQdUwzt8+IO++sJiVbwBgwSg1Giyc2qMThEYPLK3QNFArgCsIDR6wQuS8t66pJsRPQ==}
@@ -8552,6 +8559,33 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  '@platforma-sdk/block-tools@2.13.0(@types/node@24.5.2)':
+    dependencies:
+      '@aws-sdk/client-ecr-public': 3.859.0
+      '@aws-sdk/client-s3': 3.859.0
+      '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.4.20
+      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-middle-layer': 1.31.0
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.6
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      '@platforma-sdk/package-builder-lib': 1.3.0
+      canonicalize: 2.1.0
+      commander: 15.0.0
+      lru-cache: 11.2.2
+      mime-types: 2.1.35
+      tar: 7.4.3
+      undici: 7.16.0
+      yaml: 2.8.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/node'
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.0
@@ -8571,6 +8605,21 @@ snapshots:
       zod: 3.25.76
 
   '@platforma-sdk/package-builder-lib@1.2.1':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
+      '@milaboratories/resolve-helper': 1.1.3
+      archiver: 7.0.1
+      undici: 7.16.0
+      winston: 3.17.0
+      yaml: 2.8.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@platforma-sdk/package-builder-lib@1.3.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.81.1
   '@platforma-sdk/tengo-builder': 4.0.22
   '@platforma-sdk/package-builder': 3.14.2
-  '@platforma-sdk/block-tools': 2.12.13
+  '@platforma-sdk/block-tools': 2.13.0
   '@platforma-sdk/test': 1.81.2
   '@milaboratories/helpers': 1.14.5
   '@milaboratories/graph-maker': 1.4.8

--- a/ui/src/importFile.ts
+++ b/ui/src/importFile.ts
@@ -5,7 +5,7 @@ import * as XLSX from "xlsx";
 import { parseFastaContent, fastaToTable } from "./fastaParser";
 
 // Define a more specific type for raw Excel data
-type TableRow = string[];
+type TableRow = (string | undefined)[];
 type TableData = TableRow[];
 
 // Helper function to infer data type from a value
@@ -213,7 +213,25 @@ export function processFileBytes(bytes: Uint8Array, extension: string | undefine
     return;
   }
 
-  if (new Set(header).size !== header.length) {
+  const namedColumns: { colIndex: number; header: string }[] = [];
+  // Data rows can be wider than the header row (trailing headerless columns)
+  const columnCount = rawData.reduce((max, row) => Math.max(max, row.length), 0);
+  for (let colIndex = 0; colIndex < columnCount; colIndex++) {
+    const columnHeader = header[colIndex];
+    if (columnHeader !== undefined && String(columnHeader).trim() !== "") {
+      namedColumns.push({ colIndex, header: columnHeader });
+      continue;
+    }
+    for (let rowIndex = 1; rowIndex < rawData.length; rowIndex++) {
+      const value = rawData[rowIndex][colIndex];
+      if (value !== undefined && String(value).trim() !== "") {
+        app.model.data.fileImportError = `Column ${colIndex + 1} has data but no header. Add a header to import it, or clear the column.`;
+        return;
+      }
+    }
+  }
+
+  if (new Set(namedColumns.map((c) => c.header)).size !== namedColumns.length) {
     app.model.data.fileImportError = "Headers in the input file must be unique";
     return;
   }
@@ -221,8 +239,7 @@ export function processFileBytes(bytes: Uint8Array, extension: string | undefine
   const importColumns: ImportColumnInfo[] = [];
 
   // Process each column to infer its type
-  for (let colIndex = 0; colIndex < header.length; colIndex++) {
-    const columnHeader = header[colIndex];
+  for (const { colIndex, header: columnHeader } of namedColumns) {
     const columnValues = rawData.slice(1).map((row) => row[colIndex]);
     const inferredType = inferColumnType(columnValues);
     const sequenceType = inferredType === "String" ? inferSequenceType(columnValues) : undefined;

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -160,14 +160,13 @@ const assayFileBytes = computed(() => {
 });
 
 // For remote files: detect columns once the prerun has imported the file and
-// bytes arrive. Guarded so it doesn't re-run if a local file already processed
-// bytes synchronously. The harness flags any `outputs → data` watcher as a
+// bytes arrive. Always reprocesses so state persisted by an older block version
+// is re-validated. The harness flags any `outputs → data` watcher as a
 // hairpin; here the multi-client write race is muted because both clients
 // compute identical `importColumns`/`detectedXsvType` from identical bytes,
 // making racing writes idempotent.
 watch(assayFileBytes, (bytes) => {
   if (!bytes || !app.model.data.fileHandle) return;
-  if (app.model.data.importColumns !== undefined) return;
   processFileBytes(bytes, app.model.data.fileExtension);
 });
 
@@ -389,10 +388,6 @@ const similarityTypeOptions = [
           columns.
         </template>
       </PlFileInput>
-      <!-- @TODO: delete this after bug with not working error message in PlFileInput is fixed -->
-      <span v-if="app.model.data.fileImportError" style="color: red">
-        {{ app.model.data.fileImportError }}
-      </span>
 
       <PlDropdown
         v-model="app.model.data.sequenceColumnHeader"


### PR DESCRIPTION
Handle empty columns in inputs to immune-assay-data

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR validates headerless spreadsheet columns, skips columns that are entirely empty, and revalidates persisted imports when file bytes become available. It also updates the build tooling needed for the file-input error presentation.

- Important touched terms:
  - `TableRow`: the in-memory representation of one imported row; changed to permit `undefined` cells produced by sparse spreadsheets.
  - `namedColumns`: indexed columns with non-empty headers; introduced so only valid named columns participate in uniqueness checks and type inference.
  - `columnCount`: the maximum row width in an imported table; introduced to detect data columns extending beyond the header row.
  - `fileImportError`: user-facing import-validation state; now receives a specific error when a headerless column contains data and is displayed through `PlFileInput`.
  - `importColumns`: inferred metadata for importable named columns; now excludes fully empty headerless columns and is recomputed when reactive file bytes arrive.
  - `assayFileBytes`: reactive bytes emitted after the workflow imports a local or remote file; its watcher now reprocesses persisted imports instead of stopping when column metadata already exists.
  - `@platforma-sdk/block-tools`: repository build and packaging tooling; upgraded from 2.12.13 to 2.13.0.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no concrete blocking or independently actionable non-blocking issue was identified.

The new validation preserves physical column indexes, rejects populated headerless columns with a clear error, skips only fully empty headerless columns, and deterministically rebuilds import metadata from the same bytes.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ui/src/importFile.ts | Adds sparse-cell typing and validates every physical column, rejecting headerless data while excluding fully empty columns from imported metadata. |
| ui/src/pages/MainPage.vue | Revalidates imported bytes on reactive updates and relies on the file-input component’s error rendering. |
| pnpm-workspace.yaml | Updates the shared block-tools catalog dependency to 2.13.0. |
| pnpm-lock.yaml | Records the block-tools and package-builder-lib dependency updates without establishing a newly reachable security issue. |
| .changeset/empty-column-import.md | Documents the corrected empty-column and headerless-data import behavior as a patch release. |

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6745: bump block-tools to 2.13.0"](https://github.com/platforma-open/immune-assay-data/commit/cc60f2ade2380ba0c38280bac33a0fb3b4a7b6ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54343845)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->