### PR TITLE
Milab-6720: accept imported antibody sets

### DIFF
--- a/.changeset/imported-receptor-sets-are-not-peptides.md
+++ b/.changeset/imported-receptor-sets-are-not-peptides.md
@@ -1,0 +1,42 @@
+---
+'@platforma-open/milaboratories.immune-assay-data.model': minor
+'@platforma-open/milaboratories.immune-assay-data.workflow': minor
+'@platforma-open/milaboratories.immune-assay-data': minor
+---
+
+Treat imported receptor sets as receptors, not as peptides
+
+`import-vdj-data` emits bare imported sets — amino-acid variable domains with no gene calls and
+no counts — on `pl7.app/variantKey`, the axis peptide-extraction already uses. The block read
+that axis NAME as "peptide" in three places, so such a dataset could be selected and then went
+nowhere:
+
+- **The sequence-column picker was empty.** For `variantKey` the block installed the peptide
+  matcher (`pl7.app/sequence` + `pl7.app/feature: peptide`), which matches nothing an imported
+  set emits. `targetRef` is required, so Run never enabled.
+- **The workflow would have panicked** the moment the picker was fixed: the same test required
+  a `pl7.app/sequenceLength` column that an imported set does not carry, and the run died on
+  `"Peptide input is missing required pl7.app/sequenceLength column"` — naming a column the
+  scientist never chose. Downstream of that flag, the short-peptide k-mer override (k=5,
+  relaxed prefilter) would have been applied to ~120 aa variable domains.
+- **The UI applied peptide thresholds** — sequence-identity at 1.0/1.0 rather than
+  alignment-score at 0.9/0.95 — and the outputs were labelled "Matched Peptides" and
+  "Peptide to assay link".
+
+The question is now asked of the axis DOMAIN, which is the only thing that separates the three
+producers sharing that axis: `pl7.app/peptide/extractionRunId` is peptide-extraction,
+`pl7.app/repertoire/extractionRunId` is synthetic-repertoire-profiler, and
+`pl7.app/vdj/clonotypingRunId` is an imported receptor set. Peptide behaviour is unchanged.
+
+The workflow's copy lives in a new `modality.lib.tengo` shared by `main` and `build-outputs`,
+which previously tested the axis independently — a disagreement between them would have sent a
+dataset down the peptide alignment path while labelling its outputs as clones.
+
+Paired imported sets take the per-chain matcher. Legacy MiXCR single-cell declares pairing on
+the axis name; an imported set declares it only in the `pl7.app/vdj/scClonotypeChain` column
+domain, so the block probes for such a column instead of trusting the axis. A single-chain
+imported set is bulk-shaped and takes the unfiltered matcher, as bulk MiXCR does.
+
+The scFv probe is now skipped for peptides rather than for `variantKey`, so it reaches imported
+sets. They carry no scFv column today, so nothing is offered — the guard just stops being wrong
+about why.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     with:
       app-name: 'Block: Immune Assay Data'
       app-name-slug: 'block-immune-assay-data'
-      node-version: '20.x'
+      node-version: '22.x'
       gha-runner-label: hz-ubuntu-dind
       build-script-name: 'build:dev-local'
       build-before-publish-script-name: 'build:release'

--- a/.github/workflows/mark-stable.yaml
+++ b/.github/workflows/mark-stable.yaml
@@ -15,7 +15,7 @@ jobs:
     uses: milaboratory/github-ci/.github/workflows/block-mark-stable.yaml@v4
     with:
       app-name: 'Block: Immune Assay Data - Mark Stable'
-      node-version: '20.x'
+      node-version: '22.x'
       npmrc-config: |
         {
           "registries": {

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -90,6 +90,23 @@ function deriveDefaultLabel(data: BlockData): string {
   });
 }
 
+/**
+ * Whether a dataset's row axis holds peptides.
+ *
+ * `pl7.app/variantKey` is shared by three producers and the axis name alone does not say which:
+ * peptide-extraction stamps `pl7.app/peptide/extractionRunId`, synthetic-repertoire-profiler
+ * stamps `pl7.app/repertoire/extractionRunId`, and import-vdj-data's bare receptor sets stamp
+ * `pl7.app/vdj/clonotypingRunId`. Only the first is peptide.
+ *
+ * This is the block's one modality question, and it decides three things that used to be read
+ * off the axis name: which sequence columns are offered, which threshold defaults the UI
+ * applies, and — in the workflow — whether the short-peptide k-mer override is switched on.
+ */
+export function isPeptideAxis(axis: PColumnSpec["axesSpec"][number] | undefined): boolean {
+  if (axis?.name !== "pl7.app/variantKey") return false;
+  return axis.domain?.["pl7.app/vdj/clonotypingRunId"] === undefined;
+}
+
 function getAnchoredClonotypeProps(
   ctx: Pick<RenderCtxBase<BlockArgs, BlockData>, "data" | "resultPool">,
 ): Column[] | undefined {
@@ -172,7 +189,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
       if (ctx.data.datasetRef === undefined) return undefined;
       const spec = ctx.resultPool.getPColumnSpecByRef(ctx.data.datasetRef);
       if (spec === undefined) return undefined;
-      return spec.axesSpec[1]?.name === "pl7.app/variantKey" ? "peptide" : "antibody_tcr";
+      return isPeptideAxis(spec.axesSpec[1]) ? "peptide" : "antibody_tcr";
     },
     { retentive: true },
   )
@@ -181,15 +198,33 @@ export const platforma = BlockModelV3.create(blockDataModel)
     const ref = ctx.data.datasetRef;
     if (ref === undefined) return undefined;
 
-    const datasetAxis = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1]?.name;
+    const datasetSpec = ctx.resultPool.getPColumnSpecByRef(ref);
+    const datasetAxis = datasetSpec?.axesSpec[1];
+    const isPeptide = isPeptideAxis(datasetAxis);
+
+    // Whether records carry two chains in one frame, in the `pl7.app/vdj/scClonotypeChain`
+    // COLUMN domain. Legacy MiXCR single-cell says so on the axis name; an imported paired set
+    // says it only on the columns, so ask for such a column rather than trusting the axis.
+    const perChainColumns = isPeptide
+      ? undefined
+      : ctx.resultPool.getAnchoredPColumns({ main: ref }, [
+          {
+            name: "pl7.app/vdj/sequence",
+            domain: { "pl7.app/vdj/scClonotypeChain/index": "primary" },
+          },
+        ]);
+    const isPaired =
+      datasetAxis?.name === "pl7.app/vdj/scClonotypeKey" || (perChainColumns?.length ?? 0) > 0;
+
     const sequenceMatchers = [];
-    if (datasetAxis === "pl7.app/variantKey") {
+    if (isPeptide) {
       sequenceMatchers.push({
         axes: [{ anchor: "main", idx: 1 }],
         name: "pl7.app/sequence",
         domain: { "pl7.app/feature": "peptide" },
       });
-    } else if (datasetAxis === "pl7.app/vdj/scClonotypeKey") {
+    } else if (isPaired) {
+      // Primary allele only — a secondary would offer the same chain twice.
       sequenceMatchers.push({
         axes: [{ anchor: "main", idx: 1 }],
         name: "pl7.app/vdj/sequence",
@@ -213,7 +248,7 @@ export const platforma = BlockModelV3.create(blockDataModel)
     // datasets without such columns are unaffected. Alphabet is left
     // unconstrained: the block resolves it from the chosen column via the
     // `targetSequenceType` output, and both nt and aa constructs are emitted.
-    if (datasetAxis !== "pl7.app/variantKey") {
+    if (!isPeptide) {
       const scFvColumns = ctx.resultPool.getAnchoredPColumns({ main: ref }, [
         { name: "pl7.app/vdj/scFv-sequence" },
       ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 1.18.3
       version: 1.18.3
     '@platforma-sdk/block-tools':
-      specifier: 2.12.13
-      version: 2.12.13
+      specifier: 2.14.3
+      version: 2.14.3
     '@platforma-sdk/model':
       specifier: 1.81.1
       version: 1.81.1
@@ -92,7 +92,7 @@ importers:
         version: 1.6.2(@types/node@24.5.2)(rollup@4.55.1)(sass-embedded@1.89.0)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.0)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -122,7 +122,7 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
         version: 1.81.1
@@ -137,7 +137,7 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.8(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.8(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.5
@@ -159,7 +159,7 @@ importers:
         version: 1.4.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
       eslint:
         specifier: 'catalog:'
         version: 9.27.0
@@ -171,7 +171,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/check-content-empty:
     devDependencies:
@@ -180,7 +180,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/coverage-mode-calc:
     devDependencies:
@@ -189,7 +189,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/fasta-to-tsv:
     devDependencies:
@@ -198,7 +198,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/merge-results:
     devDependencies:
@@ -207,7 +207,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/prepare-fasta:
     devDependencies:
@@ -216,7 +216,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/sequence-match:
     devDependencies:
@@ -225,7 +225,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/split-fasta:
     devDependencies:
@@ -234,7 +234,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   software/xlsx-to-csv:
     devDependencies:
@@ -243,7 +243,7 @@ importers:
         version: 1.7.7
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.12.13(@types/node@24.5.2)
+        version: 2.14.3(@types/node@24.5.2)
 
   ui:
     dependencies:
@@ -252,10 +252,10 @@ importers:
         version: 3.2.1
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.8(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.8(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.18(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.47.18(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -1162,6 +1162,10 @@ packages:
     resolution: {integrity: sha512-IPzh5bSibr02DMKpwlCW6TuHVxaDe2o6tjaEJ4P2y5lshRbe5SBR/ne/G/N7E7KEKxmpWq7ZapOCLkLyvqFFDw==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.14.7':
+    resolution: {integrity: sha512-HIjPfGAYRRD0hbq5YSTkWt5XgBiv+yYtw73EjWLxui8eUEeB2ffdgsvH7IhVx2oXjUOL4p7M4i8PBnmdJ3830w==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-config@1.8.5':
     resolution: {integrity: sha512-XnfYXSSkRxeImQ21k6I8y5apisvagcSgMGfEeyRxNdSGwUVJbbI8TwJk+XBEDQ4lErW8oqtLxKjFQuHJMzRUoQ==}
 
@@ -1193,17 +1197,26 @@ packages:
   '@milaboratories/pl-model-backend@1.4.20':
     resolution: {integrity: sha512-AkV+PhmQms6WPwR3E75THrkD9fFE7OpfsIUC297HvnFUoCFXR6GOMGPworA/qipXReTmv192AqBpuaLdgAngyg==}
 
+  '@milaboratories/pl-model-backend@1.4.21':
+    resolution: {integrity: sha512-Z2z5J8bglslgXXoi1aySi1ho+/d+ylJiuEaRw9XTNuE5iBM3EQPe0rw095pXGOinTlMpmvUcCI2wkVCraUQ1dA==}
+
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
   '@milaboratories/pl-model-common@1.47.3':
     resolution: {integrity: sha512-tXmKujm+6ru/Fh9hr9H3iRBWbS+JE0Q7FNualtzJpijaB3SNtScR4erLTamdANv5RYNn7kbYpDWr6wAjAOajrg==}
 
+  '@milaboratories/pl-model-common@1.48.0':
+    resolution: {integrity: sha512-oCVrjFNmjQolb7YWnbSGHnp6GGVm1PhG1lnNABp9lqYjvA2ISjIPQLIo/vT2ca0mqwLrEvbuRqiqSFOg7sQ5tQ==}
+
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
   '@milaboratories/pl-model-middle-layer@1.31.0':
     resolution: {integrity: sha512-D1vyGABBtCYyp2IhKd9eMoZtKUj1wUYpIzz4Xz5k+bfJWGEF8GmZGiOvO4oOvrsEsXlG4NyO249MnBKmHFcppQ==}
+
+  '@milaboratories/pl-model-middle-layer@1.32.0':
+    resolution: {integrity: sha512-X1iLGgOwzkw8mQ/GfTxfOTJakBJ26np85h5HqUziMbVkFL0SR7wpd7xpgUs6TKVkYNM8viAv3iA2k63Yc5SahQ==}
 
   '@milaboratories/pl-tree@1.13.6':
     resolution: {integrity: sha512-R3wnMjbCNfAsyGJe3FQOqEyrNePd9ZCwkjDj2ps7d9oeiJ7QX6hYkIVuMlq8IQNYOJybfHc/dFEvWeYE3uAAZg==}
@@ -1596,6 +1609,10 @@ packages:
     resolution: {integrity: sha512-eWUIjK6D2/Ce779uyOGw9pET6KOQ7FKHg+DDrrkGh/ZllE2f/f4mghc/FPeOJIBQXVGg7Jg01oWh08SYVBzB5w==}
     hasBin: true
 
+  '@platforma-sdk/block-tools@2.14.3':
+    resolution: {integrity: sha512-CD0NPfUoXiJhl6JArC057oCXbqKkJf5HJsmrlZShnh6lKRaIQlibF8VUqbpBi9+PopsGCQ4/s5HnLR7wQoWDzg==}
+    hasBin: true
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
@@ -1605,6 +1622,9 @@ packages:
 
   '@platforma-sdk/package-builder-lib@1.2.1':
     resolution: {integrity: sha512-H6weitj7JxbiJSlteEFLafTJ+tfty6iv/imf3ysy8oCS8AZIRJk2VMW3M/aAc+xVkQeX7oVIwMwFMYrJIoFsAg==}
+
+  '@platforma-sdk/package-builder-lib@1.3.0':
+    resolution: {integrity: sha512-CdBjmNo6E1fBxKYWaXa49L/L2WLURxs2f1TAqxLIZlHRE4DZ6E1TEj3jNNKESWp+/9rwtLkTAzmTzNPrDgz+2Q==}
 
   '@platforma-sdk/tengo-builder@4.0.22':
     resolution: {integrity: sha512-8+zDYDFFI2tQS7dplTcxgQdUwzt8+IO++sJiVbwBgwSg1Giyc2qMThEYPLK3QNFArgCsIDR6wQuS8t66pJsRPQ==}
@@ -7777,12 +7797,12 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.8(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/graph-maker@1.4.8(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
       '@milaboratories/helpers': 1.14.5
       '@milaboratories/miplots4': 1.2.3(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.6(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)
+      '@milaboratories/pf-plots': 1.4.6(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)
       '@platforma-sdk/model': 1.81.1
       '@platforma-sdk/ui-vue': 1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/d3-hierarchy': 3.1.7
@@ -7843,11 +7863,11 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.18(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.18(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)(@platforma-sdk/ui-vue@1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.2
       '@milaboratories/miplots4': 1.2.3(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.6(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)
+      '@milaboratories/pf-plots': 1.4.6(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)
       '@platforma-sdk/model': 1.81.1
       '@platforma-sdk/ui-vue': 1.81.1(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       vue: 3.5.24(typescript@5.9.3)
@@ -7874,10 +7894,10 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.6(@milaboratories/pl-model-common@1.47.3)(@platforma-sdk/model@1.81.1)':
+  '@milaboratories/pf-plots@1.4.6(@milaboratories/pl-model-common@1.48.0)(@platforma-sdk/model@1.81.1)':
     dependencies:
       '@milaboratories/helpers': 1.14.5
-      '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/pl-model-common': 1.48.0
       '@platforma-sdk/model': 1.81.1
       canonicalize: 2.1.0
       lodash: 4.17.21
@@ -7924,6 +7944,24 @@ snapshots:
       '@grpc/grpc-js': 1.14.4
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-common': 1.47.3
+      '@milaboratories/ts-helpers': 1.8.6
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.14.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.0
+
+  '@milaboratories/pl-client@3.14.7':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.48.0
       '@milaboratories/ts-helpers': 1.8.6
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.14.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -8055,6 +8093,12 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-backend@1.4.21':
+    dependencies:
+      '@milaboratories/pl-client': 3.14.7
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-common@1.46.2':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -8063,6 +8107,14 @@ snapshots:
       zod: 3.25.76
 
   '@milaboratories/pl-model-common@1.47.3':
+    dependencies:
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
+      es-toolkit: 1.39.10
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-common@1.48.0':
     dependencies:
       '@milaboratories/helpers': 1.14.5
       '@milaboratories/pl-error-like': 1.12.10
@@ -8082,6 +8134,14 @@ snapshots:
     dependencies:
       '@milaboratories/helpers': 1.14.5
       '@milaboratories/pl-model-common': 1.47.3
+      es-toolkit: 1.39.10
+      utility-types: 3.11.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.32.0':
+    dependencies:
+      '@milaboratories/helpers': 1.14.5
+      '@milaboratories/pl-model-common': 1.48.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
@@ -8552,6 +8612,33 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  '@platforma-sdk/block-tools@2.14.3(@types/node@24.5.2)':
+    dependencies:
+      '@aws-sdk/client-ecr-public': 3.859.0
+      '@aws-sdk/client-s3': 3.859.0
+      '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-backend': 1.4.21
+      '@milaboratories/pl-model-common': 1.48.0
+      '@milaboratories/pl-model-middle-layer': 1.32.0
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.6
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
+      '@platforma-sdk/package-builder-lib': 1.3.0
+      canonicalize: 2.1.0
+      commander: 15.0.0
+      lru-cache: 11.2.2
+      mime-types: 2.1.35
+      tar: 7.4.3
+      undici: 7.16.0
+      yaml: 2.8.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@types/node'
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
+
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.0
@@ -8571,6 +8658,21 @@ snapshots:
       zod: 3.25.76
 
   '@platforma-sdk/package-builder-lib@1.2.1':
+    dependencies:
+      '@aws-sdk/client-s3': 3.859.0
+      '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
+      '@milaboratories/resolve-helper': 1.1.3
+      archiver: 7.0.1
+      undici: 7.16.0
+      winston: 3.17.0
+      yaml: 2.8.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - aws-crt
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@platforma-sdk/package-builder-lib@1.3.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,7 @@ catalog:
   '@platforma-sdk/ui-vue': 1.81.1
   '@platforma-sdk/tengo-builder': 4.0.22
   '@platforma-sdk/package-builder': 3.14.2
-  '@platforma-sdk/block-tools': 2.12.13
+  '@platforma-sdk/block-tools': 2.14.3
   '@platforma-sdk/test': 1.81.2
   '@milaboratories/helpers': 1.14.5
   '@milaboratories/graph-maker': 1.4.8

--- a/workflow/src/build-outputs.tpl.tengo
+++ b/workflow/src/build-outputs.tpl.tengo
@@ -5,6 +5,8 @@ pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec")
 maps := import("@platforma-sdk/workflow-tengo:maps")
 strings := import("@platforma-sdk/workflow-tengo:strings")
 
+modality := import(":modality")
+
 self.awaitState("uniqueValuesMap", "ResourceReady")
 self.awaitState("datasetSpec", "ResourceReady")
 self.awaitState("assaySequenceType", "ResourceReady")
@@ -15,12 +17,14 @@ assayColumnName := func(header) {
 }
 
 self.body(func(inputs) {
-	// Display labels reflect what the upstream actually carries — clones for
-	// VDJ, peptides for peptide-extraction. Column/axis `name`s stay neutral
-	// (`pl7.app/assay/*`); labels diverge because the upstream-side semantics
-	// differ: queryCount counts clones vs peptides, and the linker column's
-	// `target` axis is `clonotypeKey` vs `variantKey` — different identities.
-	isPeptide := inputs.datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	// Display labels reflect what the upstream actually carries — clones for VDJ, peptides for
+	// peptide-extraction. Column/axis `name`s stay neutral (`pl7.app/assay/*`); labels diverge
+	// because the upstream-side semantics differ: queryCount counts clones vs peptides, and the
+	// linker column's `target` axis is a different identity in each case.
+	//
+	// Which one it is comes from the axis DOMAIN, not its name: an imported receptor set is
+	// carried on `pl7.app/variantKey` too, and is clones.
+	isPeptide := modality.isPeptideDataset(inputs.datasetSpec)
 	matchedCountLabel := isPeptide ? "Matched Peptides" : "Matched Clones"
 	linkerLabel := isPeptide ? "Peptide to assay link" : "Clone to assay link"
 

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -11,6 +11,8 @@ text := import("text")
 render := import("@platforma-sdk/workflow-tengo:render")
 strings := import("@platforma-sdk/workflow-tengo:strings")
 
+modality := import(":modality")
+
 prerunTpl := assets.importTemplate(":prerun")
 analysisTpl := assets.importTemplate(":analysis")
 processOutputsTpl := assets.importTemplate(":process-outputs")
@@ -59,7 +61,10 @@ wf.body(func(args) {
 	// Detect peptide modality and compute min peptide length when applicable.
 	// Drives the short-peptide k-mer override in run-alignment (k=5 + relaxed
 	// mmseqs2 prefilter for inputs below the auto-tune floor of ~6).
-	isPeptide := datasetSpec.axesSpec[1].name == "pl7.app/variantKey"
+	//
+	// Not the axis name: import-vdj-data's bare receptor sets share `pl7.app/variantKey` with
+	// peptide-extraction, and are neither short nor carriers of a peptide length column.
+	isPeptide := modality.isPeptideDataset(datasetSpec)
 	minPeptideLength := undefined
 	if isPeptide {
 		peptideLenCols := args.columns.getColumns("peptideSequenceLength")

--- a/workflow/src/modality.lib.tengo
+++ b/workflow/src/modality.lib.tengo
@@ -1,0 +1,40 @@
+// Which modality a selected dataset is, from its row axis.
+//
+// Single source of truth, shared by `main` (which uses it to decide whether the short-peptide
+// k-mer override applies) and `build-outputs` (which uses it to label the outputs). The two
+// used to test the axis name independently, and a test that disagreed between them would send
+// a dataset down the peptide alignment path while labelling its outputs as clones.
+//
+// Mirrors `isPeptideAxis` in model/src/index.ts, which decides the same question for the
+// sequence-column picker and the UI's threshold defaults.
+
+ll := import("@platforma-sdk/workflow-tengo:ll")
+
+/**
+ * Whether the dataset holds peptides.
+ *
+ * `pl7.app/variantKey` is shared by three producers and the axis name alone does not say which:
+ * peptide-extraction stamps `pl7.app/peptide/extractionRunId`, synthetic-repertoire-profiler
+ * stamps `pl7.app/repertoire/extractionRunId`, and import-vdj-data's bare receptor sets stamp
+ * `pl7.app/vdj/clonotypingRunId`. Only the first is peptide.
+ *
+ * Reading the axis name alone sent an imported receptor set down the peptide path, where it
+ * was required to carry a `pl7.app/sequenceLength` column it does not emit — so the run died
+ * on a panic naming a column the scientist never chose.
+ */
+isPeptideDataset := func(datasetSpec) {
+	ll.assert(!is_undefined(datasetSpec), "modality: datasetSpec is required")
+	axis := datasetSpec.axesSpec[1]
+	if is_undefined(axis) || axis.name != "pl7.app/variantKey" {
+		return false
+	}
+	domain := axis.domain
+	if is_undefined(domain) {
+		return true
+	}
+	return is_undefined(domain["pl7.app/vdj/clonotypingRunId"])
+}
+
+export ll.toStrict({
+	isPeptideDataset: isPeptideDataset
+})


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes imported receptor sets from peptides by inspecting dataset-axis domains, then applies that modality consistently to column selection, workflow behavior, thresholds, and output labels. It also updates build tooling and CI to Node 22.

- **Peptide axis** — A `pl7.app/variantKey` row axis representing peptide variants; detection now excludes axes stamped with `pl7.app/vdj/clonotypingRunId`.
- **Imported receptor set** — Amino-acid variable-domain records produced by VDJ import; these are now treated as antibody/TCR sequences rather than peptides.
- **Dataset modality** — The peptide-versus-antibody/TCR classification shared by the model and workflow; it now derives from axis name and domain metadata.
- **Paired receptor set** — Records carrying per-chain VDJ sequence columns; the model now probes for a primary-chain column when selecting the per-chain matcher.
- **Sequence matcher** — The metadata pattern used to populate selectable target columns; imported single-chain and paired sets now use VDJ matchers instead of the peptide matcher.
- **Short-peptide override** — Alignment tuning for short peptide inputs; imported receptor sets no longer activate it or require a peptide sequence-length column.
- **Output labels** — Human-readable matched-count and linker labels; imported receptor results are now labelled as clones.
- **Build tooling runtime** — The Node environment used by block-tools and CI; CI moves to Node 22 while block-tools is upgraded to 2.14.3.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with the non-blocking caveat that its new minimum Node version should be declared for local contributors.

The modality changes consistently route imported VDJ sets through receptor behavior, while the remaining issue is limited to documenting and enforcing the runtime requirement introduced by the tooling upgrade.

**Files Needing Attention:** pnpm-workspace.yaml and the root package metadata
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Adds domain-aware modality detection and pairing-aware VDJ sequence matching for imported receptor sets. |
| workflow/src/modality.lib.tengo | Introduces the workflow's shared modality classifier, mirroring the model's imported-VDJ exclusion. |
| workflow/src/main.tpl.tengo | Uses shared modality detection to avoid peptide length requirements and short-peptide tuning for imported receptor sets. |
| workflow/src/build-outputs.tpl.tengo | Uses shared modality detection to select peptide or clone output labels consistently. |
| pnpm-workspace.yaml | Upgrades block-tools to a release whose dependency chain requires Node >=22.19 without declaring that minimum locally. |
| .github/workflows/build.yaml | Moves build and release CI from Node 20.x to Node 22.x. |
| .github/workflows/mark-stable.yaml | Moves the mark-stable workflow from Node 20.x to Node 22.x. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Selected dataset] --> B{Row axis is variantKey?}
  B -- No --> R[Antibody/TCR modality]
  B -- Yes --> C{VDJ clonotypingRunId present?}
  C -- Yes --> R
  C -- No --> P[Peptide modality]
  R --> D{Primary-chain VDJ column exists?}
  D -- Yes --> E[Use paired per-chain matcher]
  D -- No --> F[Use unfiltered VDJ matcher]
  P --> G[Use peptide matcher and short-peptide alignment behavior]
  E --> H[Clone output labels and antibody thresholds]
  F --> H
  G --> I[Peptide output labels and peptide thresholds]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20platforma-open%2Fimmune-assay-data%20PR%20%2360%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=platforma-open%2Fimmune-assay-data&pr=60&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apnpm-workspace.yaml%3A25%0A**Undeclared%20Node%20runtime%20minimum**%0A%0AThe%20upgraded%20build%20tooling%20pulls%20%60%40milaboratories%2Fpl-client%403.14.7%60%2C%20which%20requires%20Node%2022.19%20or%20newer%2C%20but%20the%20repository%20does%20not%20declare%20this%20minimum%20in%20its%20package%20metadata.%20Contributors%20using%20Node%2020%20or%20an%20earlier%20Node%2022%20release%20receive%20no%20actionable%20local%20requirement%20before%20install%20or%20tooling%20execution%20fails%20under%20strict%20engine%20enforcement.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=platforma-open%2Fimmune-assay-data&pr=60&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
pnpm-workspace.yaml:25
**Undeclared Node runtime minimum**

The upgraded build tooling pulls `@milaboratories/pl-client@3.14.7`, which requires Node 22.19 or newer, but the repository does not declare this minimum in its package metadata. Contributors using Node 20 or an earlier Node 22 release receive no actionable local requirement before install or tooling execution fails under strict engine enforcement.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6720: bump block-tools to 2.14.3 a..."](https://github.com/platforma-open/immune-assay-data/commit/ece7427bbcd6cd471ea137c7f27e485632d6941e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55132203)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->